### PR TITLE
0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.7.5] 2019-12-20
 ### Fixes
 - Fix missing i18n keys when there are no mapped translations for the system's default locale [#40](https://github.com/vinifmor/bauh/issues/40)
+- Tray icon is not updating its status after an application is uninstalled
 
 ## [0.7.4] 2019-12-09
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.7.5] 2019-12-20
+### Fixes
+- Fix missing i18n keys when there are no mapped translations for the system's default locale [#40](https://github.com/vinifmor/bauh/issues/40)
+
 ## [0.7.4] 2019-12-09
 ### Improvements
 - AUR

--- a/bauh/__init__.py
+++ b/bauh/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.7.4'
+__version__ = '0.7.5'
 __app_name__ = 'bauh'
 
 import os

--- a/bauh/view/qt/window.py
+++ b/bauh/view/qt/window.py
@@ -539,6 +539,9 @@ class ManageWindow(QWidget):
             only_pkg_type = len([p for p in self.pkgs if p.model.get_type() == pkgv.model.get_type()]) >= 2
             self.recent_uninstall = True
             self.refresh_apps(pkg_types={pkgv.model.__class__} if only_pkg_type else None)
+
+            if self.tray_icon:
+                self.tray_icon.verify_updates()
         else:
             if self._can_notify_user():
                 util.notify_user('{}: {}'.format(pkgv.model.name, self.i18n['notification.uninstall.failed']))

--- a/bauh/view/util/translation.py
+++ b/bauh/view/util/translation.py
@@ -53,7 +53,7 @@ def get_locale_keys(key: str = None, locale_dir: str = resource.get_path('locale
                 break
 
     if not locale_path:
-        return key, {}
+        return current_locale if current_locale else key, {}
 
     with open(locale_path, 'r') as f:
         locale_keys = f.readlines()


### PR DESCRIPTION
### Fixes
- Fix missing i18n keys when there are no mapped translations for the system's default locale [#40](https://github.com/vinifmor/bauh/issues/40)
- Tray icon is not updating its status after an application is uninstalled