### PR TITLE
Fix pixelated icons of filter type combo

### DIFF
--- a/bauh/view/qt/apps_table.py
+++ b/bauh/view/qt/apps_table.py
@@ -294,7 +294,7 @@ class AppsTable(QTableWidget):
         pixmap = self.cache_type_icon.get(pkg.model.get_type())
 
         if not pixmap:
-            pixmap = QIcon(pkg.model.get_type_icon_path()).pixmap(QSize(16, 16))
+            pixmap = QIcon(pkg.model.get_type_icon_path()).pixmap(QSize(14,14))
             self.cache_type_icon[pkg.model.get_type()] = pixmap
 
         item = QLabel()

--- a/bauh/view/qt/window.py
+++ b/bauh/view/qt/window.py
@@ -158,6 +158,7 @@ class ManageWindow(QWidget):
         self.combo_filter_type.lineEdit().setReadOnly(True)
         self.combo_filter_type.lineEdit().setAlignment(Qt.AlignCenter)
         self.combo_filter_type.activated.connect(self._handle_type_filter)
+        self.combo_filter_type.setIconSize(QSize(14,14))
         self.combo_filter_type.addItem('--- {} ---'.format(self.i18n['type'].capitalize()), self.any_type_filter)
         self.ref_combo_filter_type = self.toolbar.addWidget(self.combo_filter_type)
 
@@ -787,7 +788,7 @@ class ManageWindow(QWidget):
                     icon = self.cache_type_filter_icons.get(app_type)
 
                     if not icon:
-                        icon = load_icon(icon_path, 14)
+                        icon = QIcon(icon_path)
                         self.cache_type_filter_icons[app_type] = icon
 
                     self.combo_filter_type.addItem(icon, app_type.capitalize(), app_type)


### PR DESCRIPTION
This change was may last commit from previous PR but somehow was overridden during the merge I guess. It fixes pixelated icon of filter type combo for HDPI resolution.
Before fix:
![before](https://user-images.githubusercontent.com/12655177/72753822-ed8ea000-3b93-11ea-967b-8010fcf95fd8.png)
After fix:
![after](https://user-images.githubusercontent.com/12655177/72753828-f2ebea80-3b93-11ea-9d4b-2bcb54e9dba0.png)
