### PR TITLE
Add flatpak reading configuration file to task manager. Issue #112

### DIFF
--- a/bauh/gems/flatpak/__init__.py
+++ b/bauh/gems/flatpak/__init__.py
@@ -1,6 +1,11 @@
 import os
 from pathlib import Path
 
+from bauh.commons import resource
+
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 SUGGESTIONS_FILE = 'https://raw.githubusercontent.com/vinifmor/bauh-files/master/flatpak/suggestions.txt'
 CONFIG_FILE = '{}/.config/bauh/flatpak.yml'.format(Path.home())
+
+def get_icon_path() -> str:
+    return resource.get_path('img/flatpak.svg', ROOT_DIR)

--- a/bauh/gems/flatpak/controller.py
+++ b/bauh/gems/flatpak/controller.py
@@ -16,7 +16,7 @@ from bauh.commons import user
 from bauh.commons.config import save_config
 from bauh.commons.html import strip_html, bold
 from bauh.commons.system import SystemProcess, ProcessHandler
-from bauh.gems.flatpak import flatpak, SUGGESTIONS_FILE, CONFIG_FILE
+from bauh.gems.flatpak import flatpak, SUGGESTIONS_FILE, CONFIG_FILE, get_icon_path
 from bauh.gems.flatpak.config import read_config
 from bauh.gems.flatpak.constants import FLATHUB_API_URL
 from bauh.gems.flatpak.model import FlatpakApplication
@@ -357,7 +357,14 @@ class FlatpakManager(SoftwareManager):
         return action == 'downgrade' and pkg.installation == 'system'
 
     def prepare(self, task_manager: TaskManager, root_password: str, internet_available: bool):
+        task_id = 'flatpak'
+        task_manager.register_task(task_id, self.i18n['flatpak.task.read_config'], get_icon_path())
+        task_manager.update_progress(task_id, 10, None)
+        
         Thread(target=read_config, args=(True,), daemon=True).start()
+        
+        task_manager.update_progress(task_id, 100, None)
+        task_manager.finish_task(task_id)
 
     def list_updates(self, internet_available: bool) -> List[PackageUpdate]:
         updates = []

--- a/bauh/gems/flatpak/resources/locale/en
+++ b/bauh/gems/flatpak/resources/locale/en
@@ -51,4 +51,5 @@ flatpak.install.install_level.title=Installation type
 flatpak.notification.disable=If you do not want to use Flatpak applications, uncheck {} in {}
 flatpak.notification.no_remotes=No Flatpak remotes set. It will not be possible to search for Flatpak apps.
 flatpak.remotes.system_flathub.error=It was not possible to add Flathub as a system repository ( remote )
+flatpak.task.read_config=Reading Configuration
 gem.flatpak.info=Applications available on Flathub and other repositories configured on your system


### PR DESCRIPTION
This is for issue #112.  The problem appears to be that no tasks are added to the Task Manager for flatpaks.  If Bauh is configured for only flatpaks then the _Initializing_ screen will loop forever until the _Skip_ button becomes available.  This is an example how to fix it; although it may be better to fix the read_config or some other change.