### PR TITLE
0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
         - sometimes crashing when there are packages to be removed 
 - AppImage
     - "Checking symlinks" initial task hanging if an installed AppImage data does not contain the installed directory field ('install_dir')   
+- Flatpak
+    - not displaying the runtimes icons on the summary window
 
 ## [0.9.7] 2020-09-11
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - Arch
     - info window: not displaying all installed files
+    - upgrade: 
+        - sometimes crashing when there are packages to be removed 
 - AppImage
     - "Checking symlinks" initial task hanging if an installed AppImage data does not contain the installed directory field ('install_dir')   
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.9.8]
 ### Fixes
 - Arch
-    - info window: not displaying all installed files 
+    - info window: not displaying all installed files
+- AppImage
+    - "Checking symlinks" initial task hanging if an installed AppImage data does not contain the installed directory field ('install_dir')   
 
 ## [0.9.7] 2020-09-11
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.8]
+### Fixes
+- Arch
+    - info window: not displaying all installed files 
+
 ## [0.9.7] 2020-09-11
 ### Features
 - Arch

--- a/bauh/__init__.py
+++ b/bauh/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.7'
+__version__ = '0.9.8'
 __app_name__ = 'bauh'
 
 import os

--- a/bauh/gems/appimage/worker.py
+++ b/bauh/gems/appimage/worker.py
@@ -190,7 +190,11 @@ class SymlinksVerifier(Thread):
                             data = None
 
                     if data and not data.get('symlink'):
+                        if not data.get('install_dir'):
+                            data['install_dir'] = '/'.join(json_file.split('/')[0:-1])
+
                         app = AppImage(**data, i18n=self.i18n)
+
                         file_path = util.find_appimage_file(app.install_dir)
 
                         if file_path:

--- a/bauh/gems/arch/pacman.py
+++ b/bauh/gems/arch/pacman.py
@@ -178,17 +178,19 @@ def map_desktop_files(*pkgnames) -> Dict[str, List[str]]:
 
 
 def list_installed_files(pkgname: str) -> List[str]:
-    installed_files = new_subprocess(['pacman', '-Qlq', pkgname])
+    installed_files = run_cmd('pacman -Qlq {}'.format(pkgname), print_error=False)
 
-    f_paths = []
+    paths = []
 
-    for out in new_subprocess(['grep', '-E', '/.+\..+[^/]$'], stdin=installed_files.stdout).stdout:
-        if out:
-            line = out.decode().strip()
-            if line:
-                f_paths.append(line)
+    if installed_files:
+        for f in installed_files.split('\n'):
+            if f:
+                f_strip = f.strip()
 
-    return f_paths
+                if f_strip and not f_strip.endswith('/'):
+                    paths.append(f_strip)
+
+    return paths
 
 
 def verify_pgp_key(key: str) -> bool:

--- a/bauh/gems/arch/updates.py
+++ b/bauh/gems/arch/updates.py
@@ -501,7 +501,7 @@ class UpdatesSummarizer:
                 deps_no_data = {dep for dep in required_by_installed if dep in context.pkgs_data}
                 deps_nodata_deps = pacman.map_required_dependencies(*deps_no_data) if deps_no_data else {}
 
-                reverse_to_remove_provided = {p: name for name, provided in to_remove_provided for p in provided}
+                reverse_to_remove_provided = {p: name for name, provided in to_remove_provided.items() for p in provided}
 
                 for pkg in required_by_installed:
                     if pkg not in context.to_remove:

--- a/bauh/gems/flatpak/model.py
+++ b/bauh/gems/flatpak/model.py
@@ -120,3 +120,7 @@ class FlatpakApplication(SoftwarePackage):
     def __eq__(self, other):
         if isinstance(other, FlatpakApplication):
             return self.id == other.id and self.installation == other.installation and self.branch == other.branch
+
+    def get_disk_icon_path(self) -> str:
+        if not self.runtime:
+            return super(FlatpakApplication, self).get_disk_icon_path()


### PR DESCRIPTION
### Fixes
- Arch
    - info window: not displaying all installed files
    - upgrade: sometimes crashing when there are packages to be removed 
- AppImage
    - "Checking symlinks" initial task hanging if an installed AppImage data does not contain the installed directory field ('install_dir')   
- Flatpak
    - not displaying the runtimes icons on the summary window