### PR TITLE
0.9.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     
 ### Fixes
 - Arch
-    - crashing when trying to upgrade repository packages which data could not be retrieved
-    - multi-threaded download: crashing when could not retrieve download data for packages to upgrade
+    - crashing when trying to upgrade repository packages which data could not be retrieved [#164](https://github.com/vinifmor/bauh/issues/164)
+    - multi-threaded download: crashing when could not retrieve download data for packages to upgrade [#164](https://github.com/vinifmor/bauh/issues/164)
 
 - Installation setup
     - wrong style resources paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     
 ### Fixes
 - Arch
-    - crashing when trying to upgrade AUR packages which data could not be retrieved
+    - crashing when trying to upgrade repository packages which data could not be retrieved
+    - multi-threaded download: crashing when could not retrieve download data for packages to upgrade
 
 - Installation setup
     - wrong style resources paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.9.14] 2021
+## [0.9.14] 2021-02-03
 ### Improvements
 - AppImage
     - caching suggestions to disk. The cache expiration can be controlled through the new property settings `suggestions.expiration` (in hours. Default: 24).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.14] 2021
+### Fixes
+- Web
+    - failing to install some applications when the expected temp directory does not exist
+
 ## [0.9.13] 2021-01-20
 ### Fixes
 - missing Python hard dependency: **packaging**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.9.14] 2021
 ### Improvements
+- AppImage
+    - caching suggestions to disk. The cache expiration can be controlled through the new property settings `suggestions.expiration` (in hours. Default: 24).
 - Web
     - nativefier URL moved to [bauh-files](https://github.com/vinifmor/bauh-files/blob/master/web/env/v1/environment.yml)
     

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.9.14] 2021
 ### Fixes
+- Installation setup
+    - wrong style resources paths
+
 - Web
     - failing to install some applications when the expected temp directory does not exist
     - using the old nativefier GitHub URL
+
+
 
 ## [0.9.13] 2021-01-20
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - nativefier URL moved to [bauh-files](https://github.com/vinifmor/bauh-files/blob/master/web/env/v1/environment.yml)
     
 ### Fixes
+- Arch
+    - crashing when trying to upgrade AUR packages which data could not be retrieved
+
 - Installation setup
     - wrong style resources paths
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - Web
     - failing to install some applications when the expected temp directory does not exist
+    - using the old nativefier GitHub URL
 
 ## [0.9.13] 2021-01-20
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.9.14] 2021
+### Improvements
+- Web
+    - nativefier URL moved to [bauh-files](https://github.com/vinifmor/bauh-files/blob/master/web/env/v1/environment.yml)
+    
 ### Fixes
 - Installation setup
     - wrong style resources paths

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ bauh is officially distributed through [PyPi](https://pypi.org/project/bauh) and
 ```
 database:
   expiration: 60  # defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+suggestions:
+    expiration: 24  # defines the period (in hours) in which the cached suggestions will be considered up to date. Use 0 if you always want to update them.
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ bauh is officially distributed through [PyPi](https://pypi.org/project/bauh) and
 - The configuration file is located at **~/.config/bauh/appimage.yml** and it allows the following customizations:
 ```
 database:
-  expiration: 60  # defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+  expiration: 60  # defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it. Default: 60.
 suggestions:
-    expiration: 24  # defines the period (in hours) in which the cached suggestions will be considered up to date. Use 0 if you always want to update them.
+    expiration: 24  # defines the period (in hours) in which the suggestions stored in disc will be considered up to date. Use 0 if you always want to update them. Default: 24.
 ```
 
 

--- a/bauh/__init__.py
+++ b/bauh/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.13'
+__version__ = '0.9.14'
 __app_name__ = 'bauh'
 
 import os

--- a/bauh/api/abstract/view.py
+++ b/bauh/api/abstract/view.py
@@ -226,6 +226,15 @@ class FormComponent(ViewComponent):
                 raise Exception("'{}' is not a {}".format(id_, FormComponent.__class__.__name__))
             return comp
 
+    def get_text_input(self, id_) -> Optional[TextInputComponent]:
+        comp = self.get_component(id_)
+
+        if comp:
+            if not isinstance(comp, TextInputComponent):
+                raise Exception("'{}' is not a {}".format(id_, TextInputComponent.__class__.__name__))
+            return comp
+
+
 
 class FileChooserComponent(ViewComponent):
 
@@ -308,4 +317,12 @@ class PanelComponent(ViewComponent):
         if comp:
             if not isinstance(comp, FormComponent):
                 raise Exception("'{}' is not a {}".format(id_, FormComponent.__class__.__name__))
+            return comp
+
+    def get_text_input(self, id_) -> Optional[TextInputComponent]:
+        comp = self.get_component(id_)
+
+        if comp:
+            if not isinstance(comp, TextInputComponent):
+                raise Exception("'{}' is not a {}".format(id_, TextInputComponent.__class__.__name__))
             return comp

--- a/bauh/gems/appimage/__init__.py
+++ b/bauh/gems/appimage/__init__.py
@@ -14,11 +14,13 @@ CONFIG_DIR = '{}/appimage'.format(CONFIG_PATH)
 UPDATES_IGNORED_FILE = '{}/updates_ignored.txt'.format(CONFIG_DIR)
 SYMLINKS_DIR = '{}/.local/bin'.format(str(Path.home()))
 URL_COMPRESSED_DATABASES = 'https://raw.githubusercontent.com/vinifmor/bauh-files/master/appimage/dbs.tar.gz'
-DATABASES_DIR = '{}/appimage'.format(CACHE_PATH)
-DATABASE_APPS_FILE = '{}/apps.db'.format(DATABASES_DIR)
-DATABASE_RELEASES_FILE = '{}/releases.db'.format(DATABASES_DIR)
-DATABASES_TS_FILE = '{}/dbs.ts'.format(DATABASES_DIR)
+APPIMAGE_CACHE_PATH = '{}/appimage'.format(CACHE_PATH)
+DATABASE_APPS_FILE = '{}/apps.db'.format(APPIMAGE_CACHE_PATH)
+DATABASE_RELEASES_FILE = '{}/releases.db'.format(APPIMAGE_CACHE_PATH)
+DATABASES_TS_FILE = '{}/dbs.ts'.format(APPIMAGE_CACHE_PATH)
 DESKTOP_ENTRIES_PATH = '{}/.local/share/applications'.format(str(Path.home()))
+SUGGESTIONS_CACHED_FILE = '{}/suggestions.txt'.format(APPIMAGE_CACHE_PATH)
+SUGGESTIONS_CACHED_TS_FILE = '{}/suggestions.ts'.format(APPIMAGE_CACHE_PATH)
 
 
 def get_icon_path() -> str:

--- a/bauh/gems/appimage/config.py
+++ b/bauh/gems/appimage/config.py
@@ -11,5 +11,8 @@ class AppImageConfigManager(YAMLConfigManager):
         return {
             'database': {
                 'expiration': 60
+            },
+            'suggestions': {
+                'expiration': 24
             }
         }

--- a/bauh/gems/appimage/controller.py
+++ b/bauh/gems/appimage/controller.py
@@ -27,13 +27,13 @@ from bauh.commons import resource
 from bauh.commons.boot import CreateConfigFile
 from bauh.commons.html import bold
 from bauh.commons.system import SystemProcess, new_subprocess, ProcessHandler, run_cmd, SimpleProcess
-from bauh.gems.appimage import query, INSTALLATION_PATH, LOCAL_PATH, SUGGESTIONS_FILE, ROOT_DIR, \
+from bauh.gems.appimage import query, INSTALLATION_PATH, LOCAL_PATH, ROOT_DIR, \
     CONFIG_DIR, UPDATES_IGNORED_FILE, util, get_default_manual_installation_file_dir, DATABASE_APPS_FILE, \
-    DATABASE_RELEASES_FILE, DESKTOP_ENTRIES_PATH, DATABASES_DIR, get_icon_path
+    DATABASE_RELEASES_FILE, DESKTOP_ENTRIES_PATH, APPIMAGE_CACHE_PATH, get_icon_path
 from bauh.gems.appimage.config import AppImageConfigManager
 from bauh.gems.appimage.model import AppImage
 from bauh.gems.appimage.util import replace_desktop_entry_exec_command
-from bauh.gems.appimage.worker import DatabaseUpdater, SymlinksVerifier
+from bauh.gems.appimage.worker import DatabaseUpdater, SymlinksVerifier, AppImageSuggestionsDownloader
 
 RE_DESKTOP_ICON = re.compile(r'Icon\s*=\s*.+\n')
 RE_ICON_ENDS_WITH = re.compile(r'.+\.(png|svg)$')
@@ -629,6 +629,10 @@ class AppImageManager(SoftwareManager):
                             create_config=create_config, http_client=self.context.http_client,
                             logger=self.context.logger).start()
 
+            AppImageSuggestionsDownloader(taskman=task_manager, i18n=self.context.i18n,
+                                          http_client=self.context.http_client, logger=self.context.logger,
+                                          create_config=create_config).start()
+
     def list_updates(self, internet_available: bool) -> List[PackageUpdate]:
         res = self.read_installed(disk_loader=None, internet_available=internet_available)
 
@@ -641,7 +645,7 @@ class AppImageManager(SoftwareManager):
         return updates
 
     def list_warnings(self, internet_available: bool) -> List[str]:
-        dbfiles = glob.glob('{}/*.db'.format(DATABASES_DIR))
+        dbfiles = glob.glob('{}/*.db'.format(APPIMAGE_CACHE_PATH))
 
         if not dbfiles or len({f for f in (DATABASE_APPS_FILE, DATABASE_RELEASES_FILE) if f in dbfiles}) != 2:
             return [self.i18n['appimage.warning.missing_db_files'].format(appimage=bold('AppImage'))]
@@ -652,16 +656,16 @@ class AppImageManager(SoftwareManager):
         connection = self._get_db_connection(DATABASE_APPS_FILE)
 
         if connection:
-            file = self.http_client.get(SUGGESTIONS_FILE)
+            suggestions = AppImageSuggestionsDownloader(appimage_config=self.configman.get_config(), logger=self.logger,
+                                                        i18n=self.i18n, http_client=self.http_client,
+                                                        taskman=TaskManager()).read()
 
-            if not file or not file.text:
-                self.logger.warning("No suggestion found in {}".format(SUGGESTIONS_FILE))
+            if not suggestions:
+                self.logger.warning("Could not read suggestions")
                 return res
             else:
                 self.logger.info("Mapping suggestions")
                 try:
-                    sugs = [l for l in file.text.split('\n') if l]
-
                     if filter_installed:
                         installed = {i.name.lower() for i in self.read_installed(disk_loader=None, connection=connection).installed}
                     else:
@@ -669,7 +673,7 @@ class AppImageManager(SoftwareManager):
 
                     sugs_map = {}
 
-                    for s in sugs:
+                    for s in suggestions:
                         lsplit = s.split('=')
 
                         name = lsplit[1].strip()

--- a/bauh/gems/appimage/controller.py
+++ b/bauh/gems/appimage/controller.py
@@ -738,22 +738,31 @@ class AppImageManager(SoftwareManager):
         appimage_config = self.configman.get_config()
         max_width = floor(screen_width * 0.15)
 
-        opts = [
+        comps = [
             TextInputComponent(label=self.i18n['appimage.config.database.expiration'],
-                               value=int(appimage_config['database']['expiration']) if isinstance(appimage_config['database']['expiration'], int) else '',
+                               value=int(appimage_config['database']['expiration']) if isinstance(
+                                   appimage_config['database']['expiration'], int) else '',
                                tooltip=self.i18n['appimage.config.database.expiration.tip'],
                                only_int=True,
                                max_width=max_width,
-                               id_='appim_db_exp')
+                               id_='appim_db_exp'),
+            TextInputComponent(label=self.i18n['appimage.config.suggestions.expiration'],
+                               value=int(appimage_config['suggestions']['expiration']) if isinstance(
+                                   appimage_config['suggestions']['expiration'], int) else '',
+                               tooltip=self.i18n['appimage.config.suggestions.expiration.tip'],
+                               only_int=True,
+                               max_width=max_width,
+                               id_='appim_sugs_exp')
         ]
 
-        return PanelComponent([FormComponent(opts, self.i18n['appimage.config.database'])])
+        return PanelComponent([FormComponent(components=comps, id_='form')])
 
     def save_settings(self, component: PanelComponent) -> Tuple[bool, Optional[List[str]]]:
         appimage_config = self.configman.get_config()
 
-        panel = component.components[0]
-        appimage_config['database']['expiration'] = panel.get_component('appim_db_exp').get_int_value()
+        form = component.get_form_component('form')
+        appimage_config['database']['expiration'] = form.get_text_input('appim_db_exp').get_int_value()
+        appimage_config['suggestions']['expiration'] = form.get_text_input('appim_sugs_exp').get_int_value()
 
         try:
             self.configman.save_config(appimage_config)

--- a/bauh/gems/appimage/resources/locale/ca
+++ b/bauh/gems/appimage/resources/locale/ca
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Downloading database files
 appimage.update_database.uncompressing=Uncompressing files
 appimage.task.db_update=Actualització de bases de dades
 appimage.task.db_update.checking=Checking for updates
+appimage.task.suggestions=Downloading suggestions
 appimage.task.symlink_check=Checking symlinks
 appimage.uninstall.error.remove_folder=No s’ha pogut suprimir el directori d’instal·lació de l’aplicació {}
 appimage.warning.missing_db_files={appimage} database files were not found. Some actions will not work properly.

--- a/bauh/gems/appimage/resources/locale/ca
+++ b/bauh/gems/appimage/resources/locale/ca
@@ -1,6 +1,7 @@
-appimage.config.database=Database
-appimage.config.database.expiration=Expiration
+appimage.config.database.expiration=Database expiration
 appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+appimage.config.suggestions.expiration=Suggestions expiration
+appimage.config.suggestions.expiration.tip=It defines the period (in hours) in which the suggestions stored in disc will be considered up to date. Use 0 if you always want to update them.
 appimage.custom_action.install_file=Install AppImage file
 appimage.custom_action.install_file.details=Installation details
 appimage.custom_action.install_file.invalid_file=You must define a valid AppImage file

--- a/bauh/gems/appimage/resources/locale/de
+++ b/bauh/gems/appimage/resources/locale/de
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Downloading database files
 appimage.update_database.uncompressing=Uncompressing files
 appimage.task.db_update=Updating databases
 appimage.task.db_update.checking=Checking for updates
+appimage.task.suggestions=Downloading suggestions
 appimage.task.symlink_check=Checking symlinks
 appimage.uninstall.error.remove_folder=Anwendungordner {} konnte nicht entfernt werden
 appimage.warning.missing_db_files={appimage} database files were not found. Some actions will not work properly.

--- a/bauh/gems/appimage/resources/locale/de
+++ b/bauh/gems/appimage/resources/locale/de
@@ -1,6 +1,7 @@
-appimage.config.database=Database
-appimage.config.database.expiration=Expiration
+appimage.config.database.expiration=Database expiration
 appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+appimage.config.suggestions.expiration=Suggestions expiration
+appimage.config.suggestions.expiration.tip=It defines the period (in hours) in which the suggestions stored in disc will be considered up to date. Use 0 if you always want to update them.
 appimage.custom_action.install_file=Install AppImage file
 appimage.custom_action.install_file.details=Installation details
 appimage.custom_action.install_file.invalid_file=You must define a valid AppImage file

--- a/bauh/gems/appimage/resources/locale/en
+++ b/bauh/gems/appimage/resources/locale/en
@@ -1,6 +1,7 @@
-appimage.config.database=Database
-appimage.config.database.expiration=Expiration
-appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date. Use 0 if you always want to update it.
+appimage.config.database.expiration=Database expiration
+appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+appimage.config.suggestions.expiration=Suggestions expiration
+appimage.config.suggestions.expiration.tip=It defines the period (in hours) in which the suggestions stored in disc will be considered up to date. Use 0 if you always want to update them.
 appimage.custom_action.install_file=Install AppImage file
 appimage.custom_action.install_file.details=Installation details
 appimage.custom_action.install_file.invalid_file=You must define a valid AppImage file

--- a/bauh/gems/appimage/resources/locale/en
+++ b/bauh/gems/appimage/resources/locale/en
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Downloading database files
 appimage.update_database.uncompressing=Uncompressing files
 appimage.task.db_update=Updating databases
 appimage.task.db_update.checking=Checking for updates
+appimage.task.suggestions=Downloading suggestions
 appimage.task.symlink_check=Checking symlinks
 appimage.uninstall.error.remove_folder=Could not remove the application installation directory {}
 appimage.warning.missing_db_files={appimage} database files were not found. Some actions will not work properly.

--- a/bauh/gems/appimage/resources/locale/es
+++ b/bauh/gems/appimage/resources/locale/es
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Descargando archivos de la base de datos
 appimage.update_database.uncompressing=Descomprindo archivos
 appimage.task.db_update=Actualizando base de datos
 appimage.task.db_update.checking=Buscando actualizaciones
+appimage.task.suggestions=Descargando sugerencias
 appimage.task.symlink_check=Verificando links simbólicos
 appimage.uninstall.error.remove_folder=No se pudo eliminar el directorio de instalación de la aplicación {}
 appimage.warning.missing_db_files=No se encontraron archivos de la base de datos {appimage}. Algunas acciones no funcionarán correctamente.

--- a/bauh/gems/appimage/resources/locale/es
+++ b/bauh/gems/appimage/resources/locale/es
@@ -1,6 +1,7 @@
-appimage.config.database=Base de datos
-appimage.config.database.expiration=Expiración
+appimage.config.database.expiration=Expiración de la base de datos
 appimage.config.database.expiration.tip=Define el período (en minutos) en el que la base de datos será considerada actualizada durante el proceso de inicialización. Use 0 si siempre desea actualizarla.
+appimage.config.suggestions.expiration=Expiración de sugerencias
+appimage.config.suggestions.expiration.tip=Define el período (en horas) en el que la sugerencias almacenadas en disco seran consideradas actualizadas. Use 0 si desea siempre actualizarlas.
 appimage.custom_action.install_file=Instalar archivo AppImage
 appimage.custom_action.install_file.details=Detalles de instalación
 appimage.custom_action.install_file.invalid_file=Debe definir un archivo AppImage válido

--- a/bauh/gems/appimage/resources/locale/fr
+++ b/bauh/gems/appimage/resources/locale/fr
@@ -1,7 +1,7 @@
-appimage.config.database=Database
-appimage.config.database.expiration=Expiration
-appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date. Use 0 if you always want to update it.
-appimage.custom_action.install_file=Installer fichier AppImage
+appimage.config.database.expiration=Database expiration
+appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+appimage.config.suggestions.expiration=Suggestions expiration
+appimage.config.suggestions.expiration.tip=It defines the period (in hours) in which the suggestions stored in disc will be considered up to date. Use 0 if you always want to update them.appimage.custom_action.install_file=Installer fichier AppImage
 appimage.custom_action.install_file.details=Détails d'installation
 appimage.custom_action.install_file.invalid_file=Vous devez définir un fichier AppImage valide
 appimage.custom_action.install_file.invalid_name=Vous devez choisir un nom à l'application

--- a/bauh/gems/appimage/resources/locale/fr
+++ b/bauh/gems/appimage/resources/locale/fr
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Downloading database files
 appimage.update_database.uncompressing=Uncompressing files
 appimage.task.db_update=Mise à jour des bases de données
 appimage.task.db_update.checking=Checking for updates
+appimage.task.suggestions=Downloading suggestions
 appimage.task.symlink_check=Verification des symlinks
 appimage.uninstall.error.remove_folder=Impossible de supprimer le répertoire d'installation {}
 appimage.warning.missing_db_files={appimage} database files were not found. Some actions will not work properly.

--- a/bauh/gems/appimage/resources/locale/it
+++ b/bauh/gems/appimage/resources/locale/it
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Downloading database files
 appimage.update_database.uncompressing=Uncompressing files
 appimage.task.db_update=Aggiornamento dei database
 appimage.task.db_update.checking=Checking for updates
+appimage.task.suggestions=Downloading suggestions
 appimage.task.symlink_check=Checking symlinks
 appimage.uninstall.error.remove_folder=Impossibile rimuovere la directory di installazione dell'applicazione {}
 appimage.warning.missing_db_files={appimage} database files were not found. Some actions will not work properly.

--- a/bauh/gems/appimage/resources/locale/it
+++ b/bauh/gems/appimage/resources/locale/it
@@ -1,6 +1,7 @@
-appimage.config.database=Database
-appimage.config.database.expiration=Expiration
+appimage.config.database.expiration=Database expiration
 appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+appimage.config.suggestions.expiration=Suggestions expiration
+appimage.config.suggestions.expiration.tip=It defines the period (in hours) in which the suggestions stored in disc will be considered up to date. Use 0 if you always want to update them.
 appimage.custom_action.install_file=Install AppImage file
 appimage.custom_action.install_file.details=Installation details
 appimage.custom_action.install_file.invalid_file=You must define a valid AppImage file

--- a/bauh/gems/appimage/resources/locale/pt
+++ b/bauh/gems/appimage/resources/locale/pt
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Baixando arquivos do banco de dados
 appimage.update_database.uncompressing=Descomprimindo arquivos
 appimage.task.db_update=Atualizando base de dados
 appimage.task.db_update.checking=Checando atualizações
+appimage.task.suggestions=Baixando sugestões
 appimage.task.symlink_check=Verificando links simbólicos
 appimage.uninstall.error.remove_folder=Não foi possível remover o diretóri ode instalação do aplicativo {}
 appimage.warning.missing_db_files=Arquivos do banco de dados {appimage} não foram encontrados. Algumas ações não funcionarão corretamente.

--- a/bauh/gems/appimage/resources/locale/pt
+++ b/bauh/gems/appimage/resources/locale/pt
@@ -1,6 +1,7 @@
-appimage.config.database=Banco de dados
-appimage.config.database.expiration=Expiração
-appimage.config.database.expiration.tip=Define o período (em minutos) no qual o banco de dados será considerado atualizado durante o processo de inicialização. Use 0 se você quiser que ele sempre seja atualizado.
+appimage.config.database.expiration=Expiração do banco de dados
+appimage.config.database.expiration.tip=Define o período (em minutos) no qual o banco de dados será considerado atualizado durante o processo de inicialização. Use 0 se quiser que ele sempre seja atualizado.
+appimage.config.suggestions.expiration=Expiração das sugestões
+appimage.config.suggestions.expiration.tip=Define o período (em horas) no qual as sugestões armazenadas em disco serão consideradas atualizadas. Use 0 se quiser que elas sempre seja atualizadas.
 appimage.custom_action.install_file=Instalar arquivo AppImage
 appimage.custom_action.install_file.details=Detalhes de instalação
 appimage.custom_action.install_file.invalid_file=Você precisa definir um arquivo AppImage válido

--- a/bauh/gems/appimage/resources/locale/ru
+++ b/bauh/gems/appimage/resources/locale/ru
@@ -1,6 +1,7 @@
-appimage.config.database=Database
-appimage.config.database.expiration=Expiration
+appimage.config.database.expiration=Database expiration
 appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+appimage.config.suggestions.expiration=Suggestions expiration
+appimage.config.suggestions.expiration.tip=It defines the period (in hours) in which the suggestions stored in disc will be considered up to date. Use 0 if you always want to update them.
 appimage.custom_action.install_file=Установить файл AppImage
 appimage.custom_action.install_file.details=Детали установки
 appimage.custom_action.install_file.invalid_file=Вы должны определить допустимый файл AppImage

--- a/bauh/gems/appimage/resources/locale/ru
+++ b/bauh/gems/appimage/resources/locale/ru
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Downloading database files
 appimage.update_database.uncompressing=Uncompressing files
 appimage.task.db_update=Обновление базы данных
 appimage.task.db_update.checking=Checking for updates
+appimage.task.suggestions=Downloading suggestions
 appimage.task.symlink_check=Checking symlinks
 appimage.uninstall.error.remove_folder=Не удалось удалить каталог приложения {}
 appimage.warning.missing_db_files={appimage} database files were not found. Some actions will not work properly.

--- a/bauh/gems/appimage/resources/locale/tr
+++ b/bauh/gems/appimage/resources/locale/tr
@@ -1,6 +1,7 @@
-appimage.config.database=Database
-appimage.config.database.expiration=Expiration
+appimage.config.database.expiration=Database expiration
 appimage.config.database.expiration.tip=It defines the period (in minutes) in which the database will be considered up to date during the initialization process. Use 0 if you always want to update it.
+appimage.config.suggestions.expiration=Suggestions expiration
+appimage.config.suggestions.expiration.tip=It defines the period (in hours) in which the suggestions stored in disc will be considered up to date. Use 0 if you always want to update them.
 appimage.custom_action.install_file=AppImage dosyasını yükle
 appimage.custom_action.install_file.details=Kurulum detayları
 appimage.custom_action.install_file.invalid_file=Geçerli bir AppImage dosyası tanımlamanız gerekir

--- a/bauh/gems/appimage/resources/locale/tr
+++ b/bauh/gems/appimage/resources/locale/tr
@@ -37,6 +37,7 @@ appimage.update_database.downloading=Downloading database files
 appimage.update_database.uncompressing=Uncompressing files
 appimage.task.db_update=Veritabanları güncelleniyor
 appimage.task.db_update.checking=Checking for updates
+appimage.task.suggestions=Downloading suggestions
 appimage.task.symlink_check=Checking symlinks
 appimage.uninstall.error.remove_folder={} uygulama kurulum dizini kaldırılamadı
 appimage.warning.missing_db_files={appimage} database files were not found. Some actions will not work properly.

--- a/bauh/gems/arch/download.py
+++ b/bauh/gems/arch/download.py
@@ -160,6 +160,12 @@ class MultithreadedDownloadService:
         downloaded = 0
         pkgs_data = pacman.list_download_data(pkgs)
 
+        if not pkgs_data:
+            error_msg = "Could not retrieve download data of the following packages: {}".format(', '.join(pkgs))
+            watcher.print(error_msg)
+            self.logger.error(error_msg)
+            return 0
+
         for pkg in pkgs_data:
             self.logger.info('Preparing to download package: {} ({})'.format(pkg['n'], pkg['v']))
             try:

--- a/bauh/gems/arch/pacman.py
+++ b/bauh/gems/arch/pacman.py
@@ -632,8 +632,8 @@ def map_updates_data(pkgs: Iterable[str], files: bool = False) -> dict:
     else:
         output = run_cmd('pacman -Si {}'.format(' '.join(pkgs)))
 
+    res = {}
     if output:
-        res = {}
         latest_name = None
         data = {'ds': None, 's': None, 'v': None, 'c': None, 'p': None, 'd': None, 'r': None}
         latest_field = None
@@ -713,7 +713,7 @@ def map_updates_data(pkgs: Iterable[str], files: bool = False) -> dict:
                     else:
                         data[latest_field].update((w.strip() for w in l.split(' ') if w))
 
-        return res
+    return res
 
 
 def upgrade_several(pkgnames: Iterable[str], root_password: str, overwrite_conflicting_files: bool = False, skip_dependency_checks: bool = False) -> SimpleProcess:

--- a/bauh/gems/arch/pacman.py
+++ b/bauh/gems/arch/pacman.py
@@ -599,8 +599,8 @@ def map_provided(remote: bool = False, pkgs: Iterable[str] = None) -> Dict[str, 
 def list_download_data(pkgs: Iterable[str]) -> List[Dict[str, str]]:
     _, output = system.run(['pacman', '-Si', *pkgs])
 
+    res = []
     if output:
-        res = []
         data = {'a': None, 'v': None, 'r': None, 'n': None}
 
         for l in output.split('\n'):
@@ -623,7 +623,7 @@ def list_download_data(pkgs: Iterable[str]) -> List[Dict[str, str]]:
                         res.append(data)
                         data = {'a': None, 'v': None, 'r': None, 'n': None}
 
-        return res
+    return res
 
 
 def map_updates_data(pkgs: Iterable[str], files: bool = False) -> dict:

--- a/bauh/gems/arch/updates.py
+++ b/bauh/gems/arch/updates.py
@@ -8,7 +8,7 @@ from packaging.version import parse as parse_version
 
 from bauh.api.abstract.controller import UpgradeRequirements, UpgradeRequirement
 from bauh.api.abstract.handler import ProcessWatcher
-from bauh.gems.arch import pacman, sorting, aur
+from bauh.gems.arch import pacman, sorting
 from bauh.gems.arch.aur import AURClient
 from bauh.gems.arch.dependencies import DependenciesAnalyser
 from bauh.gems.arch.exceptions import PackageNotFoundException
@@ -327,19 +327,21 @@ class UpdatesSummarizer:
         requirement = UpgradeRequirement(pkg)
 
         if pkg.repository != 'aur':
-            data = context.pkgs_data[pkg.name]
-            requirement.required_size = data['ds']
-            requirement.extra_size = data['s']
-    
-            current_size = installed_sizes.get(pkg.name) if installed_sizes else None
+            pkgdata = context.pkgs_data.get(pkg.name)
 
-            if current_size is not None and data['s']:
-                requirement.extra_size = data['s'] - current_size
+            if pkgdata:
+                requirement.required_size = pkgdata['ds']
+                requirement.extra_size = pkgdata['s']
+    
+                current_size = installed_sizes.get(pkg.name) if installed_sizes else None
+
+                if current_size is not None and pkgdata['s']:
+                    requirement.extra_size = pkgdata['s'] - current_size
 
             required_by = set()
 
             if to_install and to_sync and context.pkgs_data:
-                names = context.pkgs_data[pkg.name].get('p', {pkg.name})
+                names = pkgdata.get('p', {pkg.name}) if pkgdata else {pkg.name}
                 to_sync_deps_cache = {}
                 for p in to_sync:
                     if p != pkg.name and p in context.pkgs_data:

--- a/bauh/gems/web/__init__.py
+++ b/bauh/gems/web/__init__.py
@@ -32,7 +32,6 @@ SEARCH_INDEX_FILE = '{}/index.yml'.format(WEB_CACHE_PATH)
 SUGGESTIONS_CACHE_FILE = '{}/suggestions.yml'.format(WEB_CACHE_PATH)
 SUGGESTIONS_CACHE_TS_FILE = map_timestamp_file(SUGGESTIONS_CACHE_FILE)
 CONFIG_FILE = '{}/web.yml'.format(CONFIG_PATH)
-URL_NATIVEFIER = 'https://github.com/nativefier/nativefier/archive/v{version}.tar.gz'
 ENVIRONMENT_SETTINGS_CACHED_FILE = '{}/environment.yml'.format(WEB_CACHE_PATH)
 ENVIRONMENT_SETTINGS_TS_FILE = '{}/environment.ts'.format(WEB_CACHE_PATH)
 

--- a/bauh/gems/web/__init__.py
+++ b/bauh/gems/web/__init__.py
@@ -32,7 +32,7 @@ SEARCH_INDEX_FILE = '{}/index.yml'.format(WEB_CACHE_PATH)
 SUGGESTIONS_CACHE_FILE = '{}/suggestions.yml'.format(WEB_CACHE_PATH)
 SUGGESTIONS_CACHE_TS_FILE = map_timestamp_file(SUGGESTIONS_CACHE_FILE)
 CONFIG_FILE = '{}/web.yml'.format(CONFIG_PATH)
-URL_NATIVEFIER = 'https://github.com/jiahaog/nativefier/archive/v{version}.tar.gz'
+URL_NATIVEFIER = 'https://github.com/nativefier/nativefier/archive/v{version}.tar.gz'
 ENVIRONMENT_SETTINGS_CACHED_FILE = '{}/environment.yml'.format(WEB_CACHE_PATH)
 ENVIRONMENT_SETTINGS_TS_FILE = '{}/environment.ts'.format(WEB_CACHE_PATH)
 

--- a/bauh/gems/web/__init__.py
+++ b/bauh/gems/web/__init__.py
@@ -34,6 +34,7 @@ SUGGESTIONS_CACHE_TS_FILE = map_timestamp_file(SUGGESTIONS_CACHE_FILE)
 CONFIG_FILE = '{}/web.yml'.format(CONFIG_PATH)
 ENVIRONMENT_SETTINGS_CACHED_FILE = '{}/environment.yml'.format(WEB_CACHE_PATH)
 ENVIRONMENT_SETTINGS_TS_FILE = '{}/environment.ts'.format(WEB_CACHE_PATH)
+NATIVEFIER_BASE_URL = 'https://github.com/nativefier/nativefier/archive/v{version}.tar.gz'
 
 
 def get_icon_path() -> str:

--- a/bauh/gems/web/controller.py
+++ b/bauh/gems/web/controller.py
@@ -689,6 +689,9 @@ class WebApplicationManager(SoftwareManager):
                 install_options.append('--icon={}'.format(temp_icon_path))
 
                 self.logger.info("Writing a temp suggestion icon at {}".format(temp_icon_path))
+
+                Path(os.path.dirname(temp_icon_path)).mkdir(parents=True, exist_ok=True)
+
                 with open(temp_icon_path, 'wb+') as f:
                     f.write(icon_bytes)
 

--- a/bauh/gems/web/environment.py
+++ b/bauh/gems/web/environment.py
@@ -22,7 +22,7 @@ from bauh.commons.system import SimpleProcess, ProcessHandler
 from bauh.gems.web import ENV_PATH, NODE_DIR_PATH, NODE_BIN_PATH, NODE_MODULES_PATH, NATIVEFIER_BIN_PATH, \
     ELECTRON_PATH, ELECTRON_DOWNLOAD_URL, ELECTRON_SHA256_URL, URL_ENVIRONMENT_SETTINGS, NPM_BIN_PATH, NODE_PATHS, \
     nativefier, ELECTRON_WIDEVINE_URL, ELECTRON_WIDEVINE_SHA256_URL, \
-    ENVIRONMENT_SETTINGS_CACHED_FILE, ENVIRONMENT_SETTINGS_TS_FILE, get_icon_path
+    ENVIRONMENT_SETTINGS_CACHED_FILE, ENVIRONMENT_SETTINGS_TS_FILE, get_icon_path, NATIVEFIER_BASE_URL
 from bauh.gems.web.model import WebApplication
 from bauh.view.util.translation import I18n
 
@@ -176,7 +176,7 @@ class EnvironmentUpdater:
     def _install_nativefier(self, version: str, url: str, handler: ProcessHandler) -> bool:
         self.logger.info("Checking if nativefier@{} exists".format(version))
 
-        if not self.http_client.exists(url):
+        if not url or not self.http_client.exists(url):
             self.logger.warning("The file {} seems not to exist".format(url))
             handler.watcher.show_message(title=self.i18n['message.file.not_exist'],
                                          body=self.i18n['message.file.not_exist.body'].format(bold(url)),
@@ -448,7 +448,12 @@ class EnvironmentUpdater:
             return True
 
     def _map_nativefier_file(self, nativefier_settings: dict) -> EnvironmentComponent:
-        url = nativefier_settings['url'].format(version=nativefier_settings['version'])
+        base_url = nativefier_settings.get('url')
+        if not base_url:
+            self.logger.warning("'url' not found in nativefier environment settings. Using hardcoded URL '{}'".format(NATIVEFIER_BASE_URL))
+            base_url = NATIVEFIER_BASE_URL
+
+        url = base_url.format(version=nativefier_settings['version'])
         return EnvironmentComponent(name='nativefier@{}'.format(nativefier_settings['version']),
                                     url=url,
                                     size=self.http_client.get_content_length(url),

--- a/bauh/gems/web/environment.py
+++ b/bauh/gems/web/environment.py
@@ -21,7 +21,7 @@ from bauh.commons.html import bold
 from bauh.commons.system import SimpleProcess, ProcessHandler
 from bauh.gems.web import ENV_PATH, NODE_DIR_PATH, NODE_BIN_PATH, NODE_MODULES_PATH, NATIVEFIER_BIN_PATH, \
     ELECTRON_PATH, ELECTRON_DOWNLOAD_URL, ELECTRON_SHA256_URL, URL_ENVIRONMENT_SETTINGS, NPM_BIN_PATH, NODE_PATHS, \
-    nativefier, URL_NATIVEFIER, ELECTRON_WIDEVINE_URL, ELECTRON_WIDEVINE_SHA256_URL, \
+    nativefier, ELECTRON_WIDEVINE_URL, ELECTRON_WIDEVINE_SHA256_URL, \
     ENVIRONMENT_SETTINGS_CACHED_FILE, ENVIRONMENT_SETTINGS_TS_FILE, get_icon_path
 from bauh.gems.web.model import WebApplication
 from bauh.view.util.translation import I18n
@@ -173,10 +173,9 @@ class EnvironmentUpdater:
 
         return installed
 
-    def _install_nativefier(self, version: str, handler: ProcessHandler) -> bool:
+    def _install_nativefier(self, version: str, url: str, handler: ProcessHandler) -> bool:
         self.logger.info("Checking if nativefier@{} exists".format(version))
 
-        url = URL_NATIVEFIER.format(version=version)
         if not self.http_client.exists(url):
             self.logger.warning("The file {} seems not to exist".format(url))
             handler.watcher.show_message(title=self.i18n['message.file.not_exist'],
@@ -449,7 +448,7 @@ class EnvironmentUpdater:
             return True
 
     def _map_nativefier_file(self, nativefier_settings: dict) -> EnvironmentComponent:
-        url = URL_NATIVEFIER.format(version=nativefier_settings['version'])
+        url = nativefier_settings['url'].format(version=nativefier_settings['version'])
         return EnvironmentComponent(name='nativefier@{}'.format(nativefier_settings['version']),
                                     url=url,
                                     size=self.http_client.get_content_length(url),
@@ -496,10 +495,10 @@ class EnvironmentUpdater:
             if not self._download_and_install(version=node_data.version, version_url=node_data.url, watcher=handler.watcher):
                 return False
 
-            if not self._install_nativefier(version=nativefier_data.version, handler=handler):
+            if not self._install_nativefier(version=nativefier_data.version, url=nativefier_data.url, handler=handler):
                 return False
         else:
-            if nativefier_data and not self._install_nativefier(version=nativefier_data.version, handler=handler):
+            if nativefier_data and not self._install_nativefier(version=nativefier_data.version, url=nativefier_data.url, handler=handler):
                 return False
 
         electron_data = comp_map.get('electron')

--- a/bauh/view/core/controller.py
+++ b/bauh/view/core/controller.py
@@ -477,7 +477,7 @@ class GenericSoftwareManager(SoftwareManager):
             mti = time.time()
             man_sugs = man.list_suggestions(limit=limit, filter_installed=filter_installed)
             mtf = time.time()
-            self.logger.info(man.__class__.__name__ + ' took {0:.2f} seconds'.format(mtf - mti))
+            self.logger.info(man.__class__.__name__ + ' took {0:.5f} seconds'.format(mtf - mti))
 
             if man_sugs:
                 if 0 < limit < len(man_sugs):

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires=">=3.5",
     url=URL,
     packages=find_packages(exclude=["tests.*", "tests"]),
-    package_data={NAME: ["view/resources/locale/*", "view/resources/img/*",  "view/styles/*", 'view/styles/*/img/*', "gems/*/resources/img/*", "gems/*/resources/locale/*", "desktop/*"]},
+    package_data={NAME: ["view/resources/locale/*", "view/resources/img/*",  "view/resources/style/*", 'view/resources/style/*/img/*', "gems/*/resources/img/*", "gems/*/resources/locale/*", "desktop/*"]},
     install_requires=requirements,
     test_suite="tests",
     entry_points={


### PR DESCRIPTION
### Improvements
- AppImage
    - caching suggestions to disk. The cache expiration can be controlled through the new property settings `suggestions.expiration` (in hours. Default: 24).
- Web
    - nativefier URL moved to [bauh-files](https://github.com/vinifmor/bauh-files/blob/master/web/env/v1/environment.yml)
    
### Fixes
- Arch
    - crashing when trying to upgrade repository packages which data could not be retrieved [#164](https://github.com/vinifmor/bauh/issues/164)
    - multi-threaded download: crashing when could not retrieve download data for packages to upgrade [#164](https://github.com/vinifmor/bauh/issues/164)

- Installation setup
    - wrong style resources paths

- Web
    - failing to install some applications when the expected temp directory does not exist
    - using the old nativefier GitHub URL