### PR TITLE
0.9.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.16]
+### Fixes
+- Arch
+    - not skipping dependency checking when the user opts to proceed with a transaction that would break other packages
+
+
 ## [0.9.15] 2021-03-03
 ### Improvements
 - UI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - Arch
     - not skipping dependency checking when the user opts to proceed with a transaction that would break other packages
-    - AUR: not restoring the CPUs to previous scaling governors after the package is built when optimizations are on 
+    - AUR: not restoring the CPUs to previous scaling governors after the package is built when optimizations are on
+    - randomly crashing when solving repository packages dependencies (RuntimeError: dictionary changed size during iteration)
 
 ## [0.9.15] 2021-03-03
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - Arch
     - not skipping dependency checking when the user opts to proceed with a transaction that would break other packages
-
+    - AUR: not restoring the CPUs to previous scaling governors after the package is built when optimizations are on 
 
 ## [0.9.15] 2021-03-03
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.9.16]
+## [0.9.16] 2021-04-06
 ### Fixes
 - Arch
     - not skipping dependency checking when the user opts to proceed with a transaction that would break other packages
     - AUR: not restoring the CPUs to previous scaling governors after the package is built when optimizations are on
     - randomly crashing when solving repository packages dependencies (RuntimeError: dictionary changed size during iteration)
+
 
 ## [0.9.15] 2021-03-03
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ suggestions:
     
     c) `ccache` will be added to `BUILDENV` if it is installed on the system and already not defined 
     
-    d) set the device processors to performance mode
+    d) set the device CPUs to performance scaling governor
 
     Obs: For more information about them, have a look at [Makepkg](https://wiki.archlinux.org/index.php/Makepkg)
 

--- a/bauh/__init__.py
+++ b/bauh/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.15'
+__version__ = '0.9.16'
 __app_name__ = 'bauh'
 
 import os

--- a/bauh/gems/arch/cpu_manager.py
+++ b/bauh/gems/arch/cpu_manager.py
@@ -1,6 +1,8 @@
 import multiprocessing
 import os
 import traceback
+from logging import Logger
+from typing import Optional, Set, Tuple, Dict
 
 from bauh.commons.system import new_root_subprocess
 
@@ -9,30 +11,67 @@ def supports_performance_mode():
     return os.path.exists('/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor')
 
 
-def all_in_performance() -> bool:
-    for i in range(multiprocessing.cpu_count()):
-        with open('/sys/devices/system/cpu/cpu{}/cpufreq/scaling_governor'.format(i)) as f:
-            if f.read().strip() != 'performance':
-                return False
+def current_governors() -> Dict[str, Set[int]]:
+    governors = {}
+    for cpu in range(multiprocessing.cpu_count()):
+        with open('/sys/devices/system/cpu/cpu{}/cpufreq/scaling_governor'.format(cpu)) as f:
+            gov = f.read().strip()
+            cpus = governors.get(gov, set())
+            cpus.add(cpu)
+            governors[gov] = cpus
 
-    return False
+    return governors
 
 
-def set_mode(mode: str, root_password: str):
+def set_governor(governor: str, root_password: str, cpu_idxs: Optional[Set[int]] = None):
     new_gov_file = '/tmp/bauh_scaling_governor'
     with open(new_gov_file, 'w+') as f:
-        f.write(mode)
+        f.write(governor)
 
-    for i in range(multiprocessing.cpu_count()):
+    for idx in (cpu_idxs if cpu_idxs else range(multiprocessing.cpu_count())):
+        _change_governor(idx, new_gov_file, root_password)
+
+    if os.path.exists(new_gov_file):
         try:
-            gov_file = '/sys/devices/system/cpu/cpu{}/cpufreq/scaling_governor'.format(i)
-            replace = new_root_subprocess(['cp', new_gov_file, gov_file], root_password=root_password)
-            replace.wait()
+            os.remove(new_gov_file)
         except:
             traceback.print_exc()
 
-        if os.path.exists(new_gov_file):
-            try:
-                os.remove(new_gov_file)
-            except:
-                traceback.print_exc()
+
+def _change_governor(cpu_idx: int, new_gov_file_path: str, root_password: str):
+    try:
+        gov_file = '/sys/devices/system/cpu/cpu{}/cpufreq/scaling_governor'.format(cpu_idx)
+        replace = new_root_subprocess(['cp', new_gov_file_path, gov_file], root_password=root_password)
+        replace.wait()
+    except:
+        traceback.print_exc()
+
+
+def set_all_cpus_to(governor: str, root_password: str, logger: Optional[Logger] = None) -> Tuple[bool, Optional[Dict[str, Set[int]]]]:
+    """
+    """
+    cpus_changed, cpu_governors = False, current_governors()
+
+    if cpu_governors:
+        not_in_performance = set()
+        for gov, cpus in cpu_governors.items():
+            if gov != governor:
+                not_in_performance.update(cpus)
+
+        if not_in_performance:
+            if logger:
+                logger.info("Changing CPUs {} governors to '{}'".format(not_in_performance, governor))
+
+            set_governor(governor, root_password, not_in_performance)
+            cpus_changed = True
+
+    return cpus_changed, cpu_governors
+
+
+def set_cpus(governors: Dict[str, Set[int]], root_password: str, ignore_governors: Optional[Set[str]] = None, logger: Optional[Logger] = None):
+    for gov, cpus in governors.items():
+        if not ignore_governors or gov not in ignore_governors:
+            if logger:
+                logger.info("Changing CPUs {} governors to '{}'".format(cpus, gov))
+
+            set_governor(gov, root_password, cpus)

--- a/bauh/gems/arch/dependencies.py
+++ b/bauh/gems/arch/dependencies.py
@@ -393,7 +393,7 @@ class DependenciesAnalyser:
                 for t in aur_threads:
                     t.join()
 
-            missing_subdeps = self.map_missing_deps(pkgs_data=deps_data, provided_map=provided_map, aur_index=aur_index,
+            missing_subdeps = self.map_missing_deps(pkgs_data={**deps_data}, provided_map=provided_map, aur_index=aur_index,
                                                     deps_checked=deps_checked, sort=False, deps_data=deps_data,
                                                     watcher=watcher,
                                                     remote_provided_map=remote_provided_map,

--- a/bauh/gems/arch/pacman.py
+++ b/bauh/gems/arch/pacman.py
@@ -723,7 +723,7 @@ def upgrade_several(pkgnames: Iterable[str], root_password: str, overwrite_confl
         cmd.append('--overwrite=*')
 
     if skip_dependency_checks:
-        cmd.append('-d')
+        cmd.append('-dd')
 
     return SimpleProcess(cmd=cmd,
                          root_password=root_password,


### PR DESCRIPTION
### Fixes
- Arch
    - not skipping dependency checking when the user opts to proceed with a transaction that would break other packages
    - AUR: not restoring the CPUs to previous scaling governors after the package is built when optimizations are on
    - randomly crashing when solving repository packages dependencies (RuntimeError: dictionary changed size during iteration)