### PR TITLE
0.9.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - AppImage
     - not displaying the filter for any kind of file (*) when updating imported AppImages [#193](https://github.com/vinifmor/bauh/issues/193)
-
+- UI
+  - always requesting the password on the initialization dialog when launched by the root user [#195](https://github.com/vinifmor/bauh/issues/195) 
 
 
 ## [0.9.19] 2021-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.9.20]
+## [0.9.20] 2021-11-05
 ### Improvements
 - AppImage:
   - not displaying "imported" besides the imported application name on the table (only for the name tip) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - AppImage
     - not displaying the filter for any kind of file (*) when updating imported AppImages [#193](https://github.com/vinifmor/bauh/issues/193)
+- Flatpak
+  - not listing installed packages for Flatpak 1.2 [#201](https://github.com/vinifmor/bauh/issues/201)
 - UI
   - always requesting the password on the initialization dialog when launched by the root user [#195](https://github.com/vinifmor/bauh/issues/195) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - always displaying the "any file filter" (*) as the last option for file chooser components [#193](https://github.com/vinifmor/bauh/issues/193)
 
 ### Fixes
+- Arch
+  - not able to install packages when launched by the root user
 - AppImage
     - not displaying the filter for any kind of file (*) when updating imported AppImages [#193](https://github.com/vinifmor/bauh/issues/193)
 - Flatpak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - always displaying the "any file filter" (*) as the last option for file chooser components [#193](https://github.com/vinifmor/bauh/issues/193)
 
 ### Fixes
-- Arch
-  - not able to install packages when launched by the root user
+- General
+  - some backend commands could hang when require user interaction 
 - AppImage
     - not displaying the filter for any kind of file (*) when updating imported AppImages [#193](https://github.com/vinifmor/bauh/issues/193)
 - Flatpak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.9.20]
+### Improvements
+- UI:
+  - always displaying the "any file filter" (*) as the last option for file chooser components [#193](https://github.com/vinifmor/bauh/issues/193)
+
 ### Fixes
 - AppImage
     - not displaying the filter for any kind of file (*) when updating imported AppImages [#193](https://github.com/vinifmor/bauh/issues/193)
+
 
 
 ## [0.9.19] 2021-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     - not displaying the filter for any kind of file (*) when updating imported AppImages [#193](https://github.com/vinifmor/bauh/issues/193)
 - Flatpak
   - not listing installed packages for Flatpak 1.2 [#201](https://github.com/vinifmor/bauh/issues/201)
+  - not listing updates for Flatpak 1.2
 - UI
   - always requesting the password on the initialization dialog when launched by the root user [#195](https://github.com/vinifmor/bauh/issues/195) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.20]
+### Fixes
+- AppImage
+    - not displaying the filter for any kind of file (*) when updating imported AppImages [#193](https://github.com/vinifmor/bauh/issues/193)
+
+
 ## [0.9.19] 2021-08-23
 ### Improvements
 - AppImage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [0.9.20]
 ### Improvements
+- AppImage:
+  - not displaying "imported" besides the imported application name on the table (only for the name tip) 
+  
 - UI:
   - always displaying the "any file filter" (*) as the last option for file chooser components [#193](https://github.com/vinifmor/bauh/issues/193)
 

--- a/bauh/__init__.py
+++ b/bauh/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.19'
+__version__ = '0.9.20'
 __app_name__ = 'bauh'
 
 import os

--- a/bauh/api/abstract/view.py
+++ b/bauh/api/abstract/view.py
@@ -235,7 +235,6 @@ class FormComponent(ViewComponent):
             return comp
 
 
-
 class FileChooserComponent(ViewComponent):
 
     def __init__(self, allowed_extensions: Optional[Set[str]] = None, label: Optional[str] = None, tooltip: Optional[str] = None,

--- a/bauh/commons/system.py
+++ b/bauh/commons/system.py
@@ -89,14 +89,12 @@ class SimpleProcess:
         args = {
             "stdout": subprocess.PIPE,
             "stderr": subprocess.STDOUT,
+            "stdin": stdin if stdin else subprocess.DEVNULL,
             "bufsize": -1,
             "cwd": cwd,
             "env": gen_env(global_interpreter, lang, extra_paths=extra_paths),
             "shell": self.shell
         }
-
-        if stdin:
-            args['stdin'] = stdin
 
         return subprocess.Popen(args=[' '.join(cmd)] if self.shell else cmd, **args)
 

--- a/bauh/gems/appimage/controller.py
+++ b/bauh/gems/appimage/controller.py
@@ -162,7 +162,8 @@ class AppImageManager(SoftwareManager):
                                             components=[FormComponent(label='', components=[file_chooser, input_version], spaces=False)],
                                             confirmation_label=self.i18n['proceed'].capitalize(),
                                             deny_label=self.i18n['cancel'].capitalize()):
-                if not file_chooser.file_path or not os.path.isfile(file_chooser.file_path):
+
+                if not file_chooser.file_path or not os.path.isfile(file_chooser.file_path) or not file_chooser.file_path.lower().strip().endswith('.appimage'):
                     watcher.request_confirmation(title=self.i18n['error'].capitalize(),
                                                  body=self.i18n['appimage.custom_action.install_file.invalid_file'],
                                                  deny_button=False)

--- a/bauh/gems/appimage/controller.py
+++ b/bauh/gems/appimage/controller.py
@@ -152,7 +152,7 @@ class AppImageManager(SoftwareManager):
 
     def update_file(self, pkg: AppImage, root_password: str, watcher: ProcessWatcher):
         file_chooser = FileChooserComponent(label=self.i18n['file'].capitalize(),
-                                            allowed_extensions={'AppImage'},
+                                            allowed_extensions={'AppImage', '*'},
                                             search_path=get_default_manual_installation_file_dir())
         input_version = TextInputComponent(label=self.i18n['version'].capitalize())
         file_chooser.observers.append(ManualInstallationFileObserver(None, input_version))

--- a/bauh/gems/appimage/model.py
+++ b/bauh/gems/appimage/model.py
@@ -102,7 +102,7 @@ class AppImage(SoftwarePackage):
     def has_screenshots(self):
         return not self.installed and self.url_screenshot
 
-    def get_display_name(self) -> str:
+    def get_name_tooltip(self) -> str:
         if self.name and self.imported:
             return '{} ({})'.format(self.name, self.i18n['imported'])
 

--- a/bauh/gems/flatpak/controller.py
+++ b/bauh/gems/flatpak/controller.py
@@ -22,7 +22,7 @@ from bauh.commons.boot import CreateConfigFile
 from bauh.commons.html import strip_html, bold
 from bauh.commons.system import ProcessHandler
 from bauh.gems.flatpak import flatpak, SUGGESTIONS_FILE, CONFIG_FILE, UPDATES_IGNORED_FILE, CONFIG_DIR, EXPORTS_PATH, \
-    get_icon_path, VERSION_1_5, VERSION_1_4
+    get_icon_path, VERSION_1_5, VERSION_1_2
 from bauh.gems.flatpak.config import FlatpakConfigManager
 from bauh.gems.flatpak.constants import FLATHUB_API_URL
 from bauh.gems.flatpak.model import FlatpakApplication
@@ -143,7 +143,7 @@ class FlatpakManager(SoftwareManager):
                 models.append(model)
 
                 if update_map and (update_map['full'] or update_map['partial']):
-                    if version >= VERSION_1_4:
+                    if version >= VERSION_1_2:
                         update_id = '{}/{}/{}'.format(app_json['id'], app_json['branch'], app_json['installation'])
 
                         if update_map['full'] and update_id in update_map['full']:

--- a/bauh/gems/flatpak/flatpak.py
+++ b/bauh/gems/flatpak/flatpak.py
@@ -93,7 +93,7 @@ def get_commit(app_id: str, branch: str, installation: str) -> Optional[str]:
 def list_installed(version: Version) -> List[dict]:
     apps = []
 
-    if version < VERSION_1_3:
+    if version < VERSION_1_2:
         app_list = new_subprocess(['flatpak', 'list', '-d'])
 
         for o in app_list.stdout:

--- a/bauh/view/qt/components.py
+++ b/bauh/view/qt/components.py
@@ -858,7 +858,13 @@ class FormQt(QGroupBox):
 
         def open_chooser(e):
             if c.allowed_extensions:
-                exts = ';;'.join({'*.{}'.format(e) for e in c.allowed_extensions})
+                sorted_exts = [e for e in c.allowed_extensions if e != '*']
+                sorted_exts.sort()
+
+                if '*' in c.allowed_extensions:
+                    sorted_exts.append('*')
+
+                exts = ';;'.join({f'*.{e}' for e in sorted_exts})
             else:
                 exts = '{} (*);;'.format(self.i18n['all_files'].capitalize())
 

--- a/bauh/view/qt/components.py
+++ b/bauh/view/qt/components.py
@@ -864,7 +864,7 @@ class FormQt(QGroupBox):
                 if '*' in c.allowed_extensions:
                     sorted_exts.append('*')
 
-                exts = ';;'.join({f'*.{e}' for e in sorted_exts})
+                exts = ';;'.join((f'*.{e}' for e in sorted_exts))
             else:
                 exts = '{} (*);;'.format(self.i18n['all_files'].capitalize())
 

--- a/bauh/view/qt/prepare.py
+++ b/bauh/view/qt/prepare.py
@@ -13,6 +13,7 @@ from bauh import __app_name__
 from bauh.api.abstract.context import ApplicationContext
 from bauh.api.abstract.controller import SoftwareManager, SoftwareAction
 from bauh.api.abstract.handler import TaskManager
+from bauh.commons import user
 from bauh.view.qt.components import new_spacer, QCustomToolbar
 from bauh.view.qt.qt_utils import centralize
 from bauh.view.qt.root import RootDialog
@@ -55,7 +56,7 @@ class Prepare(QThread, TaskManager):
 
     def run(self):
         root_pwd = None
-        if self.manager.requires_root(SoftwareAction.PREPARE, None):
+        if not user.is_root() and self.manager.requires_root(SoftwareAction.PREPARE, None):
             ok, root_pwd = self.ask_password()
 
             if not ok:


### PR DESCRIPTION
### Improvements
- AppImage:
  - not displaying "imported" besides the imported application name on the table (only for the name tip) 
  
- UI:
  - always displaying the "any file filter" (*) as the last option for file chooser components [#193](https://github.com/vinifmor/bauh/issues/193)

### Fixes
- General
  - some backend commands could hang when require user interaction 
- AppImage
    - not displaying the filter for any kind of file (*) when updating imported AppImages [#193](https://github.com/vinifmor/bauh/issues/193)
- Flatpak
  - not listing installed packages for Flatpak 1.2 [#201](https://github.com/vinifmor/bauh/issues/201)
  - not listing updates for Flatpak 1.2
- UI
  - always requesting the password on the initialization dialog when launched by the root user [#195](https://github.com/vinifmor/bauh/issues/195)