### PR TITLE
0.9.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [0.9.27] 2022-02-14
+## [0.9.28] 2022-02-14
 
 ### Fixes
 - Distribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.9.27] 2022-02-14
+
+### Fixes
+- Distribution
+  - AppImage: not able to detect updates on the **tray mode** because the `bauh-cli` call was referencing the system's Python interpreter instead of the containerized one.
+
+
 ## [0.9.27] 2022-02-11
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixes
 - Distribution
-  - AppImage: not able to detect updates on the **tray mode** because the `bauh-cli` call was referencing the system's Python interpreter instead of the containerized one.
+  - AppImage: not able to detect updates on the **tray mode** because the `bauh-cli` call was referencing the system's Python interpreter instead of the containerized one [#230](https://github.com/vinifmor/bauh/issues/230)
 
 
 ## [0.9.27] 2022-02-11

--- a/bauh/__init__.py
+++ b/bauh/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.27'
+__version__ = '0.9.28'
 __app_name__ = 'bauh'
 
 import os

--- a/bauh/view/qt/systray.py
+++ b/bauh/view/qt/systray.py
@@ -30,7 +30,7 @@ CLI_NAME = f'{__app_name__}-cli'
 
 def get_cli_path() -> str:
     if os.getenv('APPIMAGE'):
-        return CLI_NAME
+        return f"{os.environ['APPRUN_STARTUP_EXEC_PATH']} {os.environ['APPDIR']}usr/bin/{CLI_NAME}"
 
     venv = os.getenv('VIRTUAL_ENV')
 
@@ -51,7 +51,7 @@ def get_cli_path() -> str:
 def list_updates(logger: logging.Logger) -> List[PackageUpdate]:
     cli_path = get_cli_path()
     if cli_path:
-        exitcode, output = system.execute(f'{cli_path} updates -f json', custom_env=dict(os.environ))
+        exitcode, output = system.execute(f'{cli_path} updates -f json')
 
         if exitcode != 0:
             output_log = output.replace('\n', ' ') if output else ' '

--- a/linux_dist/appimage/AppImageBuilder.yml
+++ b/linux_dist/appimage/AppImageBuilder.yml
@@ -65,7 +65,7 @@ AppDir:
   runtime:
     version: "continuous"
     env:
-      PATH: '${APPDIR}/usr/bin:${PATH}'
+      PATH: '${PATH}:${APPDIR}/usr/bin'
       PYTHONHOME: '${APPDIR}/usr'
       PYTHONPATH: '${APPDIR}/usr/lib/python3.8/site-packages'
 

--- a/linux_dist/appimage/AppImageBuilder.yml
+++ b/linux_dist/appimage/AppImageBuilder.yml
@@ -65,7 +65,6 @@ AppDir:
   runtime:
     version: "continuous"
     env:
-      PATH: '${PATH}:${APPDIR}/usr/bin'
       PYTHONHOME: '${APPDIR}/usr'
       PYTHONPATH: '${APPDIR}/usr/lib/python3.8/site-packages'
 


### PR DESCRIPTION
### Fixes
- Distribution
  - AppImage: not able to detect updates on the **tray mode** because the `bauh-cli` call was referencing the system's Python interpreter instead of the containerized one [#230](https://github.com/vinifmor/bauh/issues/230)