### PR TITLE
Pyre: Optional type is missing

### DIFF
--- a/bauh/api/abstract/controller.py
+++ b/bauh/api/abstract/controller.py
@@ -58,7 +58,7 @@ class SearchResult:
 
 class UpgradeRequirement:
 
-    def __init__(self, pkg: SoftwarePackage, reason: str = None, required_size: float = None, extra_size: float = None, sorting_priority: int = 0):
+    def __init__(self, pkg: SoftwarePackage, reason: Optional[str] = None, required_size: Optional[float] = None, extra_size: Optional[float] = None, sorting_priority: int = 0):
         """
 
         :param pkg:


### PR DESCRIPTION
**"filename"**: "bauh/api/abstract/controller.py"
**"warning_type"**: "Incompatible variable type [9]",
**"warning_message"**: " reason is declared to have type `str` but is used as type `None`.",
**"warning_line"**: 61
**"fix"**: add `Optional`