### PR TITLE
0.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - some desktop entries not being displayed on the desktop environment menu (requires the AppImage to be reinstalled) [#287](https://github.com/vinifmor/bauh/issues/287)
 - Arch
   - not detecting some package replacements when upgrading due to conflict information having logic operators (e.g: `at-spi2-core: 2.44.1 -> 2.46.0` should replace the installed `at-spi2-atk: 2.38`)
+  - not considering some conflict expressions when retrieving upgrade requirements (it could lead to a system breakage depending on the conflict)
 - Debian
   - not properly handling packages with names ending with `:i386` [#298](https://github.com/vinifmor/bauh/issues/298)
 - Packaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Packaging
   - AppImage: download certificate issue [#280](https://github.com/vinifmor/bauh/issues/280)
 - GUI
-  - management panel not fully maximizing
+    - initialization panel size not based on the current display device size
+    - management panel: 
+      - not fully maximizing
+      - not maximizing based on the current display device size (for multiple display setups)
+      - not respecting a minimal/maximum width based on the current display device size (for multiple display setup)
+      - dialogs not respecting the current display device width
+      - not readjusting size after maximizing/minimizing
 
 ### Localization (i18n)
 - Italian ([@albanobattistella](https://github.com/albanobattistella), [@luca-digrazia](https://github.com/luca-digrazia))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - AppImage
   - some desktop entries not being displayed on the desktop environment menu (requires the AppImage to be reinstalled) [#287](https://github.com/vinifmor/bauh/issues/287)
+- Arch
+  - not detecting some package replacements when upgrading due to conflict information having logic operators (e.g: `at-spi2-core: 2.44.1 -> 2.46.0` should replace the installed `at-spi2-atk: 2.38`)
 - GUI
   - management panel not fully maximizing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - GUI
   - management panel not fully maximizing
 
+### Localization (i18n)
+- Italian ([@albanobattistella](https://github.com/albanobattistella), [@luca-digrazia](https://github.com/luca-digrazia))
+- Turkish ([@agahemir](https://github.com/agahemir))
+
 ## [0.10.3] 2022-05-30
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - some desktop entries not being displayed on the desktop environment menu (requires the AppImage to be reinstalled) [#287](https://github.com/vinifmor/bauh/issues/287)
 - Arch
   - not detecting some package replacements when upgrading due to conflict information having logic operators (e.g: `at-spi2-core: 2.44.1 -> 2.46.0` should replace the installed `at-spi2-atk: 2.38`)
+- Debian
+  - not properly handling packages with names ending with `:i386` [#298](https://github.com/vinifmor/bauh/issues/298)
 - GUI
   - management panel not fully maximizing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [STAGING]
 
+### Improvements
+- Arch
+  - replaced some system calls by Python calls
+
 ### Fixes
 - AppImage
   - some desktop entries not being displayed on the desktop environment menu (requires the AppImage to be reinstalled) [#287](https://github.com/vinifmor/bauh/issues/287)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [STAGING]
+## [0.10.4] 2022-11-05
 
 ### Improvements
 - Arch
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Localization (i18n)
 - Italian ([@albanobattistella](https://github.com/albanobattistella), [@luca-digrazia](https://github.com/luca-digrazia))
 - Turkish ([@agahemir](https://github.com/agahemir))
+
 
 ## [0.10.3] 2022-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - AppImage
   - some desktop entries not being displayed on the desktop environment menu (requires the AppImage to be reinstalled) [#287](https://github.com/vinifmor/bauh/issues/287)
+- GUI
+  - management panel not fully maximizing
 
 ## [0.10.3] 2022-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - not detecting some package replacements when upgrading due to conflict information having logic operators (e.g: `at-spi2-core: 2.44.1 -> 2.46.0` should replace the installed `at-spi2-atk: 2.38`)
 - Debian
   - not properly handling packages with names ending with `:i386` [#298](https://github.com/vinifmor/bauh/issues/298)
+- Packaging
+  - AppImage: download certificate issue [#280](https://github.com/vinifmor/bauh/issues/280)
 - GUI
   - management panel not fully maximizing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [STAGING]
+
+### Fixes
+- AppImage
+  - some desktop entries not being displayed on the desktop environment menu (requires the AppImage to be reinstalled) [#287](https://github.com/vinifmor/bauh/issues/287)
+
 ## [0.10.3] 2022-05-30
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ the `view` code is only attached to them (it does not know how the `gems` handle
 - Separate modules for each packaging technology
 - Memory and performance improvements
 - Improve user experience
+- The current development changes can be checked [here](https://github.com/vinifmor/bauh/blob/staging/CHANGELOG.md)
     
 #### <a name="donations">Donations</a>
 - You can support this project through [ko-fi](https://ko-fi.com/vinifmor).

--- a/bauh/__init__.py
+++ b/bauh/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.10.3'
+__version__ = '0.10.4'
 __app_name__ = 'bauh'
 
 import os

--- a/bauh/gems/appimage/controller.py
+++ b/bauh/gems/appimage/controller.py
@@ -528,13 +528,13 @@ class AppImageManager(SoftwareManager, SettingsController):
         finally:
             releases_con.close()
 
-    def _find_desktop_file(self, folder: str) -> str:
+    def _find_desktop_file(self, folder: str) -> Optional[str]:
         for r, d, files in os.walk(folder):
             for f in files:
                 if f.endswith('.desktop'):
                     return f
 
-    def _find_icon_file(self, folder: str) -> str:
+    def _find_icon_file(self, folder: str) -> Optional[str]:
         for f in glob.glob(folder + ('/**' if not folder.endswith('/') else '**'), recursive=True):
             if RE_ICON_ENDS_WITH.match(f):
                 return f

--- a/bauh/gems/appimage/util.py
+++ b/bauh/gems/appimage/util.py
@@ -2,7 +2,7 @@ import os
 import re
 from typing import Optional
 
-RE_DESKTOP_EXEC = re.compile(r'(Exec\s*=(.+)(\n?))')
+RE_DESKTOP_EXEC = re.compile(r'(\w*Exec\s*=(.+)(\n?))')
 RE_MANY_SPACES = re.compile(r'\s+')
 
 
@@ -24,6 +24,11 @@ def replace_desktop_entry_exec_command(desktop_entry: str, appname: str, file_pa
 
     for exec_groups in execs:
         full_match = exec_groups[0]
+
+        if full_match.startswith("TryExec"):  # TryExec cause issues in some DE to display the app icon
+            final_entry = final_entry.replace(full_match, "")
+            continue
+
         cmd = RE_MANY_SPACES.sub(' ', exec_groups[1].strip())
         if cmd:
             words = cmd.split(' ')

--- a/bauh/gems/appimage/util.py
+++ b/bauh/gems/appimage/util.py
@@ -2,7 +2,7 @@ import os
 import re
 from typing import Optional
 
-RE_DESKTOP_EXEC = re.compile(r'(\w*Exec\s*=(.+)(\n?))')
+RE_DESKTOP_EXEC = re.compile(r'(\n?\s*\w*Exec\s*=(.+))')
 RE_MANY_SPACES = re.compile(r'\s+')
 
 
@@ -25,7 +25,7 @@ def replace_desktop_entry_exec_command(desktop_entry: str, appname: str, file_pa
     for exec_groups in execs:
         full_match = exec_groups[0]
 
-        if full_match.startswith("TryExec"):  # TryExec cause issues in some DE to display the app icon
+        if full_match.strip().startswith("TryExec"):  # TryExec cause issues in some DE to display the app icon
             final_entry = final_entry.replace(full_match, "")
             continue
 

--- a/bauh/gems/appimage/util.py
+++ b/bauh/gems/appimage/util.py
@@ -1,15 +1,16 @@
 import os
 import re
+from typing import Optional
 
 RE_DESKTOP_EXEC = re.compile(r'(Exec\s*=(.+)(\n?))')
 RE_MANY_SPACES = re.compile(r'\s+')
 
 
-def find_appimage_file(folder: str) -> str:
+def find_appimage_file(folder: str) -> Optional[str]:
     for r, d, files in os.walk(folder):
         for f in files:
             if f.lower().endswith('.appimage'):
-                return '{}/{}'.format(folder, f)
+                return f'{folder}/{f}'
 
 
 def replace_desktop_entry_exec_command(desktop_entry: str, appname: str, file_path: str) -> str:
@@ -30,12 +31,12 @@ def replace_desktop_entry_exec_command(desktop_entry: str, appname: str, file_pa
 
             for idx in range(len(words)):
                 if words[idx].lower() == treated_name:
-                    words[idx] = '"{}"'.format(file_path)
+                    words[idx] = f'"{file_path}"'
                     changed = True
                     break
 
             if not changed:
-                words = ['"{}"'.format(file_path)]
+                words = [f'"{file_path}"']
 
             final_entry = final_entry.replace(full_match, full_match.replace(exec_groups[1], ' '.join(words)))
 

--- a/bauh/gems/arch/pacman.py
+++ b/bauh/gems/arch/pacman.py
@@ -5,7 +5,7 @@ import shutil
 import traceback
 from io import StringIO
 from threading import Thread
-from typing import List, Set, Tuple, Dict, Iterable, Optional, Any, Pattern
+from typing import List, Set, Tuple, Dict, Iterable, Optional, Any, Pattern, Collection
 
 from colorama import Fore
 
@@ -1080,4 +1080,19 @@ def map_available_packages() -> Optional[Dict[str, Any]]:
                         res[pkgname] = {'v': package_data[2].strip(),
                                         'r': package_data[0].strip(),
                                         'i': len(package_data) == 4 and 'installed' in package_data[3]}
+        return res
+
+
+def map_installed(pkgs: Optional[Collection[str]] = None) -> Optional[Dict[str, str]]:
+    output = run_cmd(f"pacman -Q {' '.join({*pkgs} if pkgs else '')}".strip(), print_error=False)
+
+    if output:
+        res = dict()
+        for raw_line in output.split("\n"):
+            line = raw_line.strip()
+
+            if line:
+                pkg_version = line.split(" ")
+                if len(pkg_version) == 2:
+                    res[pkg_version[0]] = pkg_version[1]
         return res

--- a/bauh/gems/arch/updates.py
+++ b/bauh/gems/arch/updates.py
@@ -149,12 +149,14 @@ class UpdatesSummarizer:
         for p, data in context.pkgs_data.items():
             if data['c']:
                 for c in data['c']:
-                    if c and c != p and c in context.installed_names:
-                        # source = provided_map[c]
-                        root_conflict[c] = p
+                    if c:
+                        pkg_name = DependenciesAnalyser.re_dep_operator().split(c)[0]
+                        if pkg_name != p and pkg_name in context.installed_names:
+                            # source = provided_map[c]
+                            root_conflict[pkg_name] = p
 
-                        if (p, c) in root_conflict.items():
-                            mutual_conflicts[c] = p
+                            if (p, pkg_name) in root_conflict.items():
+                                mutual_conflicts[pkg_name] = p
 
         if mutual_conflicts:
             for pkg1, pkg2 in mutual_conflicts.items():

--- a/bauh/gems/arch/updates.py
+++ b/bauh/gems/arch/updates.py
@@ -22,7 +22,7 @@ class UpdateRequirementsContext:
                  aur_to_update: Dict[str, ArchPackage], repo_to_install: Dict[str, ArchPackage],
                  aur_to_install: Dict[str, ArchPackage], to_install: Dict[str, ArchPackage],
                  pkgs_data: Dict[str, dict], cannot_upgrade: Dict[str, UpgradeRequirement],
-                 to_remove: Dict[str, UpgradeRequirement], installed_names: Set[str], provided_map: Dict[str, Set[str]],
+                 to_remove: Dict[str, UpgradeRequirement], installed_names: Dict[str, str], provided_map: Dict[str, Set[str]],
                  aur_index: Set[str], arch_config: dict, remote_provided_map: Dict[str, Set[str]], remote_repo_map: Dict[str, str],
                  root_password: Optional[str], aur_supported: bool):
         self.to_update = to_update
@@ -33,7 +33,7 @@ class UpdateRequirementsContext:
         self.pkgs_data = pkgs_data
         self.cannot_upgrade = cannot_upgrade
         self.root_password = root_password
-        self.installed_names = installed_names
+        self.installed = installed_names
         self.provided_map = provided_map
         self.to_remove = to_remove
         self.to_install = to_install
@@ -150,13 +150,20 @@ class UpdatesSummarizer:
             if data['c']:
                 for c in data['c']:
                     if c:
-                        pkg_name = DependenciesAnalyser.re_dep_operator().split(c)[0]
-                        if pkg_name != p and pkg_name in context.installed_names:
-                            # source = provided_map[c]
-                            root_conflict[pkg_name] = p
+                        name_op_exp = DependenciesAnalyser.re_dep_operator().split(c)
+                        conflict_name = name_op_exp[0]
 
-                            if (p, pkg_name) in root_conflict.items():
-                                mutual_conflicts[pkg_name] = p
+                        if conflict_name != p:
+                            conflict_version = context.installed.get(conflict_name)
+
+                            if conflict_version:
+                                if len(name_op_exp) == 1 or match_required_version(conflict_version,
+                                                                                   name_op_exp[1],
+                                                                                   name_op_exp[2]):
+                                    root_conflict[conflict_name] = p
+
+                                    if (p, conflict_name) in root_conflict.items():
+                                        mutual_conflicts[conflict_name] = p
 
         if mutual_conflicts:
             for pkg1, pkg2 in mutual_conflicts.items():
@@ -280,8 +287,8 @@ class UpdatesSummarizer:
             ti = time.time()
             self.logger.info("Filling provided names")
 
-            if not context.installed_names:
-                context.installed_names = pacman.list_installed_names()
+            if not context.installed:
+                context.installed = pacman.map_installed()
 
             installed_to_ignore = set()
 
@@ -307,8 +314,8 @@ class UpdatesSummarizer:
                         if len(split_provided) > 1 and split_provided[0] != p:
                             pacman.fill_provided_map(split_provided[0], pkgname, context.provided_map)
 
-            if installed_to_ignore:  # filling the provided names of the installed
-                installed_to_query = context.installed_names.difference(installed_to_ignore)
+            if context.installed and installed_to_ignore:  # filling the provided names of the installed
+                installed_to_query = {*context.installed}.difference(installed_to_ignore)
 
                 if installed_to_query:
                     context.provided_map.update(pacman.map_provided(remote=False, pkgs=installed_to_query))
@@ -376,7 +383,7 @@ class UpdatesSummarizer:
         remote_repo_map = pacman.map_repositories()
         context = UpdateRequirementsContext(to_update={}, repo_to_update={}, aur_to_update={}, repo_to_install={},
                                             aur_to_install={}, to_install={}, pkgs_data={}, cannot_upgrade={},
-                                            to_remove={}, installed_names=set(), provided_map={}, aur_index=set(),
+                                            to_remove={}, installed_names=dict(), provided_map={}, aur_index=set(),
                                             arch_config=arch_config, root_password=root_password,
                                             remote_provided_map=remote_provided_map, remote_repo_map=remote_repo_map,
                                             aur_supported=self.aur_supported)
@@ -606,7 +613,7 @@ class UpdatesSummarizer:
                 for r in reqs:
                     if r in transaction_pkgs:
                         reqs_in_transaction.add(r)
-                    elif r in context.installed_names:
+                    elif r in context.installed:
                         reqs_not_in_transaction.add(r)
 
             if not reqs_not_in_transaction and not reqs_in_transaction:

--- a/bauh/gems/debian/aptitude.py
+++ b/bauh/gems/debian/aptitude.py
@@ -241,7 +241,7 @@ class Aptitude:
     @property
     def re_transaction_pkg(self) -> Pattern:
         if self._re_transaction_pkg is None:
-            self._re_transaction_pkg = re.compile(r'([a-zA-Z0-9\-_@~.+]+)({\w+})?\s*\[([a-zA-Z0-9\-_@~.+:]+)'
+            self._re_transaction_pkg = re.compile(r'([a-zA-Z0-9\-_@~.+:]+)({\w+})?\s*\[([a-zA-Z0-9\-_@~.+:]+)'
                                                   r'(\s+->\s+([a-zA-Z0-9\-_@~.+:]+))?](\s*<([\-+]?[0-9.,]+\s+\w+)>)?')
 
         return self._re_transaction_pkg

--- a/bauh/manage.py
+++ b/bauh/manage.py
@@ -76,7 +76,6 @@ def new_manage_panel(app_args: Namespace, app_config: dict, logger: logging.Logg
         manage_window = ManageWindow(i18n=i18n,
                                      manager=manager,
                                      icon_cache=icon_cache,
-                                     screen_size=screen_size,
                                      config=app_config,
                                      context=context,
                                      http_client=http_client,
@@ -84,8 +83,7 @@ def new_manage_panel(app_args: Namespace, app_config: dict, logger: logging.Logg
                                      force_suggestions=force_suggestions,
                                      logger=logger)
 
-        prepare = PreparePanel(screen_size=screen_size,
-                               context=context,
+        prepare = PreparePanel(context=context,
                                manager=manager,
                                i18n=i18n,
                                manage_window=manage_window,

--- a/bauh/view/core/downloader.py
+++ b/bauh/view/core/downloader.py
@@ -86,7 +86,7 @@ class AdaptableFileDownloader(FileDownloader):
         return SimpleProcess(cmd=cmd, cwd=cwd, root_password=root_password)
 
     def _get_wget_process(self, url: str, output_path: str, cwd: str, root_password: Optional[str]) -> SimpleProcess:
-        cmd = ['wget', url, '-c', '--retry-connrefused', '-t', '10', '--no-config', '-nc']
+        cmd = ['wget', url, '-c', '--retry-connrefused', '-t', '10', '-nc']
 
         if not self.check_ssl:
             cmd.append('--no-check-certificate')

--- a/bauh/view/qt/info.py
+++ b/bauh/view/qt/info.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 
-from PyQt5.QtCore import QSize, Qt
+from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon, QCursor
 from PyQt5.QtWidgets import QDialog, QVBoxLayout, QGroupBox, \
     QLineEdit, QLabel, QGridLayout, QPushButton, QPlainTextEdit, QScrollArea, QFrame, QWidget, QSizePolicy, \
@@ -8,6 +8,7 @@ from PyQt5.QtWidgets import QDialog, QVBoxLayout, QGroupBox, \
 
 from bauh.api.abstract.cache import MemoryCache
 from bauh.view.qt.components import new_spacer
+from bauh.view.qt.qt_utils import get_current_screen_geometry
 from bauh.view.util.translation import I18n
 
 IGNORED_ATTRS = {'name', '__app__'}
@@ -15,10 +16,9 @@ IGNORED_ATTRS = {'name', '__app__'}
 
 class InfoDialog(QDialog):
 
-    def __init__(self, pkg_info: dict, icon_cache: MemoryCache, i18n: I18n, screen_size: QSize):
+    def __init__(self, pkg_info: dict, icon_cache: MemoryCache, i18n: I18n):
         super(InfoDialog, self).__init__()
         self.setWindowTitle(str(pkg_info['__app__']))
-        self.screen_size = screen_size
         self.i18n = i18n
         layout = QVBoxLayout()
         self.setLayout(layout)
@@ -108,7 +108,9 @@ class InfoDialog(QDialog):
         lower_container.layout().addWidget(self.bt_close)
         layout.addWidget(lower_container)
         self.setMinimumWidth(int(self.gbox_info.sizeHint().width() * 1.2))
-        self.setMaximumHeight(int(screen_size.height() * 0.8))
+
+        screen_height = get_current_screen_geometry().height()
+        self.setMaximumHeight(int(screen_height * 0.8))
         self.adjustSize()
 
     def _gen_show_button(self, idx: int, val):

--- a/bauh/view/qt/prepare.py
+++ b/bauh/view/qt/prepare.py
@@ -15,7 +15,7 @@ from bauh.api.abstract.controller import SoftwareManager, SoftwareAction
 from bauh.api.abstract.handler import TaskManager
 from bauh.api import user
 from bauh.view.qt.components import new_spacer, QCustomToolbar
-from bauh.view.qt.qt_utils import centralize
+from bauh.view.qt.qt_utils import centralize, get_current_screen_geometry
 from bauh.view.qt.root import RootDialog
 from bauh.view.qt.thread import AnimateProgress
 from bauh.view.util.translation import I18n
@@ -145,7 +145,7 @@ class PreparePanel(QWidget, TaskManager):
     signal_status = pyqtSignal(int)
     signal_password_response = pyqtSignal(bool, str)
 
-    def __init__(self, context: ApplicationContext, manager: SoftwareManager, screen_size: QSize,
+    def __init__(self, context: ApplicationContext, manager: SoftwareManager,
                  i18n: I18n, manage_window: QWidget, app_config: dict, force_suggestions: bool = False):
         super(PreparePanel, self).__init__(flags=Qt.CustomizeWindowHint | Qt.WindowTitleHint)
         self.i18n = i18n
@@ -153,9 +153,7 @@ class PreparePanel(QWidget, TaskManager):
         self.app_config = app_config
         self.manage_window = manage_window
         self.setWindowTitle('{} ({})'.format(__app_name__, self.i18n['prepare_panel.title.start'].lower()))
-        self.setMinimumWidth(int(screen_size.width() * 0.5))
-        self.setMinimumHeight(int(screen_size.height() * 0.35))
-        self.setMaximumHeight(int(screen_size.height() * 0.95))
+
         self.setLayout(QVBoxLayout())
         self.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Preferred)
         self.manager = manager
@@ -292,6 +290,10 @@ class PreparePanel(QWidget, TaskManager):
         super(PreparePanel, self).show()
         self.prepare_thread.start()
         centralize(self)
+        screen_size = get_current_screen_geometry()
+        self.setMinimumWidth(int(screen_size.width() * 0.5))
+        self.setMinimumHeight(int(screen_size.height() * 0.35))
+        self.setMaximumHeight(int(screen_size.height() * 0.95))
 
     def start(self, tasks: int):
         self.started_at = time.time()

--- a/bauh/view/qt/qt_utils.py
+++ b/bauh/view/qt/qt_utils.py
@@ -1,16 +1,18 @@
-from PyQt5.QtCore import Qt
+from typing import Optional, Union
+
+from PyQt5.QtCore import Qt, QRect, QPoint
 from PyQt5.QtGui import QIcon, QPixmap
-from PyQt5.QtWidgets import QWidget, QApplication
+from PyQt5.QtWidgets import QWidget, QApplication, QDesktopWidget
 
 from bauh.view.util import resource
 
+desktop: Optional[QDesktopWidget] = None
+
 
 def centralize(widget: QWidget):
-    geo = widget.frameGeometry()
-    screen = QApplication.desktop().screenNumber(QApplication.desktop().cursor().pos())
-    center_point = QApplication.desktop().screenGeometry(screen).center()
-    geo.moveCenter(center_point)
-    widget.move(geo.topLeft())
+    screen_geometry = get_current_screen_geometry()
+    widget.frameGeometry().moveCenter(screen_geometry.center())
+    widget.move(widget.frameGeometry().topLeft())
 
 
 def load_icon(path: str, width: int, height: int = None) -> QIcon:
@@ -27,3 +29,13 @@ def measure_based_on_width(percent: float) -> int:
 
 def measure_based_on_height(percent: float) -> int:
     return round(percent * QApplication.primaryScreen().size().height())
+
+
+def get_current_screen_geometry(source_widget: Optional[Union[QWidget, QPoint]] = None) -> QRect:
+    global desktop
+
+    if not desktop:
+        desktop = QDesktopWidget()
+
+    current_screen_idx = desktop.screenNumber(source_widget if source_widget else desktop.cursor().pos())
+    return desktop.screen(current_screen_idx).geometry()

--- a/bauh/view/qt/thread.py
+++ b/bauh/view/qt/thread.py
@@ -29,6 +29,7 @@ from bauh.view.core import timeshift
 from bauh.view.core.config import CoreConfigManager, BACKUP_REMOVE_METHODS, BACKUP_DEFAULT_REMOVE_METHOD
 from bauh.view.qt import commons
 from bauh.view.qt.commons import sort_packages
+from bauh.view.qt.qt_utils import get_current_screen_geometry
 from bauh.view.qt.view_model import PackageView, PackageViewStatus
 from bauh.view.util.translation import I18n
 
@@ -231,12 +232,12 @@ class UpgradeSelected(AsyncAction):
     SUMMARY_FILE = UPGRADE_LOGS_DIR + '/{}_summary.txt'
 
     def __init__(self, manager: SoftwareManager, internet_checker: InternetChecker, i18n: I18n,
-                 screen_width: int, pkgs: List[PackageView] = None):
+                 parent_widget: QWidget, pkgs: List[PackageView] = None):
         super(UpgradeSelected, self).__init__(i18n=i18n)
         self.pkgs = pkgs
         self.manager = manager
         self.internet_checker = internet_checker
-        self.screen_width = screen_width
+        self._parent_widget = parent_widget
 
     def _req_as_option(self, req: UpgradeRequirement, tooltip: bool = True, custom_tooltip: str = None, required_size: bool = True, display_sizes: bool = True,
                        positive_size_symbol: bool = False) -> InputOption:
@@ -495,9 +496,10 @@ class UpgradeSelected(AsyncAction):
         comps.insert(0, TextComponent(f'{disc_size_text} ({download_size_text})', size=14))
         comps.insert(1, TextComponent(''))
 
+        screen_width = get_current_screen_geometry(self._parent_widget).width()
         if not self.request_confirmation(title=self.i18n['action.update.summary'].capitalize(), body='', components=comps,
                                          confirmation_label=self.i18n['proceed'].capitalize(), deny_label=self.i18n['cancel'].capitalize(),
-                                         confirmation_button=can_upgrade, min_width=int(0.45 * self.screen_width)):
+                                         confirmation_button=can_upgrade, min_width=int(0.45 * screen_width)):
             self.notify_finished({'success': success, 'updated': updated, 'types': updated_types, 'id': None})
             self.pkgs = None
             return

--- a/bauh/view/qt/window.py
+++ b/bauh/view/qt/window.py
@@ -457,7 +457,6 @@ class ManageWindow(QWidget):
         self.thread_load_installed = NotifyInstalledLoaded()
         self.thread_load_installed.signal_loaded.connect(self._finish_loading_installed)
         self.setMinimumHeight(int(screen_size.height() * 0.5))
-        self.setMaximumHeight(int(screen_size.height()))
         self.setMinimumWidth(int(screen_size.width() * 0.5))
         self._register_groups()
 

--- a/bauh/view/qt/window.py
+++ b/bauh/view/qt/window.py
@@ -2,7 +2,6 @@ import logging
 import operator
 import os.path
 import time
-import traceback
 from pathlib import Path
 from typing import List, Type, Set, Tuple, Optional
 

--- a/bauh/view/qt/window.py
+++ b/bauh/view/qt/window.py
@@ -459,7 +459,6 @@ class ManageWindow(QWidget):
         self.setMinimumHeight(int(screen_size.height() * 0.5))
         self.setMaximumHeight(int(screen_size.height()))
         self.setMinimumWidth(int(screen_size.width() * 0.5))
-        self.setMaximumWidth(int(screen_size.width() - screen_size.width() * 0.015))
         self._register_groups()
 
     def _register_groups(self):

--- a/linux_dist/appimage/Dockerfile
+++ b/linux_dist/appimage/Dockerfile
@@ -13,9 +13,10 @@ RUN apt-get update && \
     chmod +x appimage-tool && \
     chmod +x appimage-builder && \
     mv /build/appimage-builder /usr/local/bin/appimage-builder && \
-    mv /build/appimage-tool /usr/local/bin/appimage-tool && \
-    wget https://raw.githubusercontent.com/vinifmor/bauh/master/linux_dist/appimage/AppImageBuilder.yml
+    mv /build/appimage-tool /usr/local/bin/appimage-tool
 
 WORKDIR /build
+
+COPY AppImageBuilder.yml /build
 
 CMD [ "appimage-builder", "--skip-tests"]

--- a/linux_dist/appimage/Dockerfile
+++ b/linux_dist/appimage/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04
+
+ARG bauh_commit
+ENV BAUH_VERSION=$bauh_commit
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get upgrade && \
+    apt-get install python3-pip python3-setuptools python3-wheel wget fuse binutils coreutils desktop-file-utils fakeroot patchelf squashfs-tools strace zsync libgdk-pixbuf2.0-dev gtk-update-icon-cache -y && \
+    mkdir /build && cd /build && \
+    wget https://github.com/AppImageCrafters/appimage-builder/releases/download/v0.9.2/appimage-builder-0.9.2-35e3eab-x86_64.AppImage -O appimage-builder && \
+    wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage -O appimage-tool && \
+    chmod +x appimage-tool && \
+    chmod +x appimage-builder && \
+    mv /build/appimage-builder /usr/local/bin/appimage-builder && \
+    mv /build/appimage-tool /usr/local/bin/appimage-tool && \
+    wget https://raw.githubusercontent.com/vinifmor/bauh/master/linux_dist/appimage/AppImageBuilder.yml
+
+WORKDIR /build
+
+CMD [ "appimage-builder", "--skip-tests"]

--- a/linux_dist/appimage/build.sh
+++ b/linux_dist/appimage/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build -t bauh-appimage --build-arg bauh_commit=$BAUH_COMMIT .
+docker run --cap-add=SYS_ADMIN --device /dev/fuse --mount type=bind,source="$(pwd)",target=/build bauh-appimage

--- a/tests/common/test_util.py
+++ b/tests/common/test_util.py
@@ -1,4 +1,3 @@
-import time
 from unittest import TestCase
 
 from bauh.commons.util import size_to_byte, sanitize_command_input

--- a/tests/common/test_view_utils.py
+++ b/tests/common/test_view_utils.py
@@ -8,7 +8,7 @@ class GetHumanSizeStrTest(TestCase):
 
     def setUp(self):
         try:
-            locale.setlocale(locale.LC_NUMERIC, None)
+            locale.setlocale(locale.LC_NUMERIC, "C")
         except:
             print("Error: could not set locale.LC_NUMERIC to None")
 

--- a/tests/gems/appimage/test_util.py
+++ b/tests/gems/appimage/test_util.py
@@ -79,6 +79,45 @@ class TestUtil(TestCase):
 
         self.assertEqual(expected, res)
 
+    def test_replace_desktop_entry_exec_command__exec_as_the_first_field(self):
+        desktop_entry = """
+        Exec=myapp %f
+        Name=MyApp
+        Icon=MyApp
+        """
+
+        res = replace_desktop_entry_exec_command(desktop_entry=desktop_entry,
+                                                 appname='myapp',
+                                                 file_path='/path/to/myapp.appimage')
+
+        expected = """
+        Exec="/path/to/myapp.appimage" %f
+        Name=MyApp
+        Icon=MyApp
+        """
+
+        self.assertEqual(expected, res)
+
+    def test_replace_desktop_entry_exec_command__try_exec_as_the_first_field(self):
+        desktop_entry = """
+        TryExec=MyApp
+        Exec=myapp %f
+        Name=MyApp
+        Icon=MyApp
+        """
+
+        res = replace_desktop_entry_exec_command(desktop_entry=desktop_entry,
+                                                 appname='myapp',
+                                                 file_path='/path/to/myapp.appimage')
+
+        expected = """
+        Exec="/path/to/myapp.appimage" %f
+        Name=MyApp
+        Icon=MyApp
+        """
+
+        self.assertEqual(expected, res)
+
     def test_replace_desktop_entry_exec_command__only_one_exec_field_with_spaces_and_params(self):
         desktop_entry = """
         Name=MyApp
@@ -136,7 +175,7 @@ class TestUtil(TestCase):
 
         self.assertEqual(expected, res)
 
-    def test_replace_desktop_entry_exec_command__only_one_tryexec_field_with_spaces_and_params(self):
+    def test_replace_desktop_entry_exec_command__must_remove_try_exec_field(self):
         desktop_entry = """
         Name=MyApp
         Icon=MyApp
@@ -150,12 +189,11 @@ class TestUtil(TestCase):
         expected = """
         Name=MyApp
         Icon=MyApp
-        TryExec ="/path/to/myapp.appimage" %f --a
         """
 
         self.assertEqual(expected, res)
 
-    def test_replace_desktop_entry_exec_command__exec_and_tryexec_fields(self):
+    def test_replace_desktop_entry_exec_command__must_replace_exec_and_remove_tryexec_fields(self):
         desktop_entry = """
         Name=MyApp
         Icon=MyApp
@@ -171,14 +209,13 @@ class TestUtil(TestCase):
         expected = """
         Name=MyApp
         Icon=MyApp
-        TryExec ="/path/to/myapp.appimage" %f
         Exec="/path/to/myapp.appimage" --a
         Terminal=false
         """
 
         self.assertEqual(expected, res)
 
-    def test_replace_desktop_entry_exec_command__exec_and_tryexec_fields_with_envvars_and_params(self):
+    def test_replace_desktop_entry_exec_command__exec_field_with_envvars_and_params(self):
         desktop_entry = """
         Name=MyApp
         Icon=MyApp
@@ -194,7 +231,6 @@ class TestUtil(TestCase):
         expected = """
         Name=MyApp
         Icon=MyApp
-        TryExec=__MY_VAR=1 "/path/to/myapp.appimage" %f
         Exec=NEW_VAR=abc "/path/to/myapp.appimage" --a
         Terminal=false
         """
@@ -228,7 +264,6 @@ Name=RPCS3
 GenericName=PlayStation 3 Emulator
 Comment=An open-source PlayStation 3 emulator/debugger written in C++.
 Icon=rpcs3
-TryExec="/path/to/rpcs3.appimage"
 Exec="/path/to/rpcs3.appimage" %f
 Terminal=false
 Categories=Game;Emulator;

--- a/tests/gems/arch/resources/pacman_ign_pkgs.conf
+++ b/tests/gems/arch/resources/pacman_ign_pkgs.conf
@@ -98,4 +98,4 @@ Include = /etc/pacman.d/mirrorlist
 #Server = file:///home/custompkgs
 ignorepkg=google-chrome
 # ignorepkg=abc
-ignorepkg  =  firefox
+IgnorePkg  =  firefox

--- a/tests/gems/debian/test_aptitude.py
+++ b/tests/gems/debian/test_aptitude.py
@@ -166,3 +166,33 @@ Description: GNU C compiler
                     ]
 
         self.assertEqual([p.__dict__ for p in expected], [p.__dict__ for p in returned])
+
+    def test_map_transaction_output__it_should_map_i386_packages(self):
+        output = "\nThe following NEW packages will be installed:\n" \
+                 " gcc-12-base:i386{a} [12.1.0-2distro~22.04] <+272 kB>  glib-networking:i386{a} [2.72.0-1] <+242 kB>\n" \
+                "\nThe following packages will be REMOVED:\n" \
+                 " celluloid{a} [0.21-linux+distro] <-1066 kB> libpcre3:i386{a} [2:8.39-13distro0.22.04.1] <-714 kB>"
+
+        transaction = self.aptitude.map_transaction_output(output)
+        to_install = {
+            DebianPackage(name="gcc-12-base:i386",
+                          version="12.1.0-2distro~22.04",
+                          latest_version="12.1.0-2distro~22.04",
+                          transaction_size=272000.0
+                          ),
+            DebianPackage(name="glib-networking:i386", version="2.72.0-1",
+                          latest_version="2.72.0-1", transaction_size=242000.0)
+        }
+        self.assertEqual(to_install, {*transaction.to_install})
+
+        to_remove = {
+            DebianPackage(name="celluloid",
+                          version="0.21-linux+distro",
+                          latest_version="0.21-linux+distro",
+                          transaction_size=-1066000.0
+                          ),
+            DebianPackage(name="libpcre3:i386", version="2:8.39-13distro0.22.04.1",
+                          latest_version="2:8.39-13distro0.22.04.1", transaction_size=-714000.0)
+        }
+
+        self.assertEqual(to_remove, {*transaction.to_remove})


### PR DESCRIPTION
### Improvements
- Arch
  - replaced some system calls by Python calls

### Fixes
- AppImage
  - some desktop entries not being displayed on the desktop environment menu (requires the AppImage to be reinstalled) [#287](https://github.com/vinifmor/bauh/issues/287)
- Arch
  - not detecting some package replacements when upgrading due to conflict information having logic operators (e.g: `at-spi2-core: 2.44.1 -> 2.46.0` should replace the installed `at-spi2-atk: 2.38`)
  - not considering some conflict expressions when retrieving upgrade requirements (it could lead to a system breakage depending on the conflict)
- Debian
  - not properly handling packages with names ending with `:i386` [#298](https://github.com/vinifmor/bauh/issues/298)
- Packaging
  - AppImage: download certificate issue [#280](https://github.com/vinifmor/bauh/issues/280)
- GUI
    - initialization panel size not based on the current display device size
    - management panel: 
      - not fully maximizing
      - not maximizing based on the current display device size (for multiple display setups)
      - not respecting a minimal/maximum width based on the current display device size (for multiple display setup)
      - dialogs not respecting the current display device width
      - not readjusting size after maximizing/minimizing

### Localization (i18n)
- Italian ([@albanobattistella](https://github.com/albanobattistella), [@luca-digrazia](https://github.com/luca-digrazia))
- Turkish ([@agahemir](https://github.com/agahemir))