### PR TITLE
[gems.arch] fix: not clearing packages to delete during loops on key

### DIFF
--- a/bauh/gems/arch/pacman.py
+++ b/bauh/gems/arch/pacman.py
@@ -145,9 +145,9 @@ def map_packages(names: Optional[Iterable[str]] = None, remote: bool = False, si
         thread_ignored.join()
 
         if ignored:
-            to_del = set()
-
             for key in ('signed', 'not_signed'):
+                to_del = set()
+                
                 if pkgs.get(key):
                     for pkg in pkgs[key].keys():
                         if pkg in ignored:


### PR DESCRIPTION
The declaration of `to_del` seemed to be misplaced, which makes bauh attempt to delete packages appeared in another package group.

E.g. if `pkg['signed']['my_pkg']` exists and `'my_pkg'` is in the ignored list, `del pkg['not_signed']['my_pkg']` would be executed too.

Fixes #329.