### PR TITLE
0.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixes
 - AppImage
   - regression on the database backend preventing long time installed AppImages to receive updates
+- UI
+  - regression from `0.10.6`:  "name" filter not working for packages whose names contain the typed words 
 
 ## [0.10.6] 2023-12-23
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - UI
   - regression from `0.10.6`:  "name" filter not working for packages whose names contain the typed words 
 
+### Distribution
+- AppImage: using the latest Python standards to build and install bauh (using `build` and `installer` packages)
+
 ## [0.10.6] 2023-12-23
 ### Features
   - new **verified** filter for the management table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [NEXT]
+### Fixes
+- AppImage
+  - regression on the database backend preventing long time installed AppImages to receive updates
+
 ## [0.10.6] 2023-12-23
 ### Features
   - new **verified** filter for the management table

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Distribution
 - AppImage: using the latest Python standards to build and install bauh (using `build` and `installer` packages)
+- PyPI: adding more exclusions to unneeded files
 
 ## [0.10.6] 2023-12-23
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [NEXT]
+## [0.10.7] 2024-01-10
 ### Fixes
 - AppImage
   - regression on the database backend preventing long time installed AppImages to receive updates

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,3 +5,6 @@ recursive-include bauh/view/resources *
 recursive-exclude bauh/view/resources *.orig
 recursive-include bauh/gems/*/resources *
 recursive-exclude bauh/gems/*/resources *.orig
+recursive-exclude linux_dist *
+recursive-exclude venv *
+recursive-exclude .venv *

--- a/bauh/__init__.py
+++ b/bauh/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.10.6'
+__version__ = '0.10.7'
 __app_name__ = 'bauh'
 
 import os

--- a/bauh/gems/appimage/model.py
+++ b/bauh/gems/appimage/model.py
@@ -55,7 +55,7 @@ class AppImage(SoftwarePackage):
                                        installed=installed)
         self.source = source
 
-        github_url = f"https://github.com/{github}" if github and not github.startswith("http://") else None
+        github_url = f"https://github.com/{github}" if github and not github.startswith("https://") else None
         self.repository = repository if repository else (github_url if github_url else repository)
         self.categories = (categories.split(',') if isinstance(categories, str) else categories) if categories else None
         self.url_download = url_download

--- a/bauh/gems/appimage/model.py
+++ b/bauh/gems/appimage/model.py
@@ -54,7 +54,9 @@ class AppImage(SoftwarePackage):
                                        icon_url=url_icon, license=license, description=description,
                                        installed=installed)
         self.source = source
-        self.repository = repository if repository else (github if github else repository)
+
+        github_url = f"https://github.com/{github}" if github and not github.startswith("http://") else None
+        self.repository = repository if repository else (github_url if github_url else repository)
         self.categories = (categories.split(',') if isinstance(categories, str) else categories) if categories else None
         self.url_download = url_download
         self.icon_path = icon_path

--- a/bauh/view/qt/view_index.py
+++ b/bauh/view/qt/view_index.py
@@ -129,7 +129,7 @@ def query_packages(index: dict, filters: PackageFilters) -> Generator[PackageVie
                     continue
 
                 # checking if the package name contains the chars query
-                if query[5] in pkgv.model.name:
+                if query[6] in pkgv.model.name:
                     yield pkgv
                     yield_count += 1
                     yielded_pkgs[pkgv.model.get_type()].add(pkgv.model.id)

--- a/bauh/view/qt/view_index.py
+++ b/bauh/view/qt/view_index.py
@@ -76,7 +76,7 @@ def generate_queries(filters: PackageFilters) -> Generator[Tuple[Optional[Union[
     chars_query = None
 
     if filters.name:
-        chars_query = filters.name.lower()
+        chars_query = filters.name.strip().lower()
 
     installed_queries = (1,) if filters.only_installed else (1, 0)
     apps_queries = (1,) if filters.only_apps else (1, 0)
@@ -129,7 +129,7 @@ def query_packages(index: dict, filters: PackageFilters) -> Generator[PackageVie
                     continue
 
                 # checking if the package name contains the chars query
-                if query[6] in pkgv.model.name:
+                if query[6] in pkgv.model.name.lower():
                     yield pkgv
                     yield_count += 1
                     yielded_pkgs[pkgv.model.get_type()].add(pkgv.model.id)

--- a/linux_dist/appimage/AppImageBuilder.yml
+++ b/linux_dist/appimage/AppImageBuilder.yml
@@ -6,12 +6,12 @@ script:
   - wget https://github.com/vinifmor/bauh/archive/${BAUH_VERSION}.tar.gz || exit 1
   - tar -xf ${BAUH_VERSION}.tar.gz || exit 1
   - cd bauh-${BAUH_VERSION} || exit 1
-  - rm pyproject.toml || exit 1  # not using the new project file definition for now
-  - BAUH_SETUP_NO_REQS=1 pip3 install . --prefix=/usr --root=../AppDir || exit 1
+  - rm setup.cfg setup.py requirements.txt || exit 1  # removing the outdated installation files
+  - python3 -m build --wheel --no-isolation || exit 1
+  - python3 -m installer --destdir=../AppDir --prefix=/usr dist/*.whl || exit 1
   - test -e ../AppDir/usr/bin/bauh || exit 1
   - cp bauh/view/resources/img/logo.svg ../AppDir/usr/share/icons/hicolor/scalable/apps/bauh.svg || exit 1
   - cp bauh/desktop/bauh.desktop ../AppDir/usr/share/applications || exit 1
-
 
 AppDir:
   path: ./AppDir
@@ -23,7 +23,6 @@ AppDir:
     version: !ENV ${BAUH_VERSION}
     exec: /usr/bin/python3
     exec_args: "$APPDIR/usr/bin/bauh $@"
-
 
   apt:
     arch: amd64
@@ -42,12 +41,12 @@ AppDir:
       - sqlite3
       - xdg-utils
     exclude:
-        - dpkg
-        - apt
-        - aptitude
-        - python3-pip
-        - python3-setuptools
-        - python3-distutils
+      - dpkg
+      - apt
+      - aptitude
+      - python3-pip
+      - python3-setuptools
+      - python3-distutils
 
   after_bundle:
       - pip3 install pyqt5==5.15.10 --prefix=/usr --root=AppDir || exit 1

--- a/linux_dist/appimage/Dockerfile
+++ b/linux_dist/appimage/Dockerfile
@@ -4,7 +4,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
     apt-get upgrade -y && \
-    apt-get install --no-install-recommends python3-pip python3-setuptools python3-wheel wget fuse binutils coreutils desktop-file-utils fakeroot patchelf squashfs-tools strace zsync libgdk-pixbuf2.0-dev gtk-update-icon-cache file -y && \
+    apt-get install --no-install-recommends python3-pip python3-build python3-setuptools python3-wheel wget fuse binutils coreutils desktop-file-utils fakeroot patchelf squashfs-tools strace zsync libgdk-pixbuf2.0-dev gtk-update-icon-cache file -y && \
+    pip3 install pip==23.3.2 setuptools==69.0.3 installer==0.7.0 && \
     mkdir /build && cd /build && \
     wget https://github.com/AppImageCrafters/appimage-builder/releases/download/v0.9.2/appimage-builder-0.9.2-35e3eab-x86_64.AppImage -O appimage-builder && \
     wget https://github.com/AppImage/AppImageKit/releases/download/13/appimagetool-x86_64.AppImage -O appimage-tool && \


### PR DESCRIPTION
### Fixes
- AppImage
  - regression on the database backend preventing long time installed AppImages to receive updates
- UI
  - regression from `0.10.6`:  "name" filter not working for packages whose names contain the typed words 

### Distribution
- AppImage: using the latest Python standards to build and install bauh (using `build` and `installer` packages)
- PyPI: adding more exclusions to unneeded files