### PR TITLE
Set application desktop filename

### DIFF
--- a/bauh/context.py
+++ b/bauh/context.py
@@ -21,6 +21,7 @@ def new_qt_application(app_config: dict, logger: Logger, quit_on_last_closed: bo
     app.setApplicationName(name if name else __app_name__)
     app.setApplicationVersion(__version__)
     app.setWindowIcon(util.get_default_icon()[1])
+    app.setDesktopFileName(__app_name__)
 
     if app_config['ui']['qt_style']:
         app.setStyle(str(app_config['ui']['qt_style']))


### PR DESCRIPTION
In Gnome 47.1 with Dash to Dock extension and Wayland, in the dock the `bauh` icon was the standard unknown application cogwheel icon.

By inspecting the window with [Looking Glass](https://wiki.gnome.org/Projects/GnomeShell/LookingGlass), one can see that the class was indeed "python3".

Simply modifying context.py new_qt_application and setting explicitly the application desktop filename seems to resolve my issue: Looking Glass shows now: `bauh | wmclass: bauh | app: bauh.desktop`.

I am using `__app_name__` as the desktop application filename assuming that if the app name changes, then the desktop filename would change as well.

Related issue: https://github.com/vinifmor/bauh/issues/372