### PR TITLE
Fix startup crash on Python 3.14 (pkgutil.find_loader removed)

### DIFF
--- a/bauh/view/core/gems.py
+++ b/bauh/view/core/gems.py
@@ -1,6 +1,7 @@
+import importlib
+import importlib.util
 import inspect
 import os
-import pkgutil
 from logging import Logger
 from typing import List, Generator
 
@@ -49,10 +50,11 @@ def load_managers(locale: str, context: ApplicationContext, config: dict, defaul
                 logger.warning(f"gem '{f.name}' could not be loaded because it was marked as forbidden in '{FORBIDDEN_GEMS_FILE}'")
                 continue
 
-            loader = pkgutil.find_loader(f'bauh.gems.{f.name}.controller')
+            mod_name = f'bauh.gems.{f.name}.controller'
+            spec = importlib.util.find_spec(mod_name)
 
-            if loader:
-                module = loader.load_module()
+            if spec:
+                module = importlib.import_module(mod_name)
 
                 manager_class = find_manager(module)
 


### PR DESCRIPTION
## Problem

bauh fails to launch on Python 3.14 with:

```
File "/usr/lib/python3.14/site-packages/bauh/view/core/gems.py", line 52, in load_managers
    loader = pkgutil.find_loader(f'bauh.gems.{f.name}.controller')
             ^^^^^^^^^^^^^^^^^^^
AttributeError: module 'pkgutil' has no attribute 'find_loader'
```

`pkgutil.find_loader` was deprecated in Python 3.12 and **removed** in Python 3.14. This breaks bauh on every distro that has moved to 3.14 (Arch, CachyOS, Fedora 41+, etc.), tracked in #402.

## Fix

Migrate `bauh/view/core/gems.py` from the removed `pkgutil` API to the modern `importlib` API:

- `pkgutil.find_loader(name)` → `importlib.util.find_spec(name)` (existence check)
- `loader.load_module()` → `importlib.import_module(name)` (actual load)

Using `importlib.import_module` is preferable to `spec.loader.load_module()` because `Loader.load_module()` has itself been deprecated since Python 3.4 and is slated for eventual removal — `import_module` is the recommended path forward.

## Verified

Tested on CachyOS with Python 3.14.4: bauh launches cleanly past the gems-loading stage and the main window renders.

## Note on #407

There's an existing PR (#407) addressing the same crash. This PR proposes a slightly cleaner alternative:
- Uses `importlib.import_module` rather than `spec.loader.load_module()` (avoids relying on a separately-deprecated API)
- Renames the local variable from `loader` to `spec` to match what it actually holds (a `ModuleSpec`)

Happy to defer to #407 if the maintainer prefers that version.  The main goal is just to get bauh launching on 3.14 again.